### PR TITLE
Add 'MaybeDefault*Generator' implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ public static void Main(string[] args) {
 ```
 
 ### [`IDistinctGenerator<T>`](src/Peddler/IDistinctGenerator.cs)
-This generates random values of `T` when the caller invokes its `NextDistinct(T)` method. The resultant value of `T` is guaranteed to be distinct from (or "not equal to") the provided value of `T`. Example:
+This generates random values of `T` when the caller invokes its `NextDistinct(T)` method. The resultant value of `T` is guaranteed to be distinct from (or "not equal to") the provided value of `T`. This interface inherits from `IGenerator<T>`. Example:
 ```cs
 using Peddler;
 
@@ -55,8 +55,7 @@ public static void Main(string[] args) {
 ```
 
 ### [`IComparableGenerator<T>`](src/Peddler/IComparableGenerator.cs)
-This generates random values of `T` when the caller invokes one of its `NextLessThan(T)`, `NextLessThanOrEqualTo(T)`, `NextGreaterThan(T)`, or `NextGreaterThanOrEqualTo(T)` methods. Depending upon which method is used, the resultant value of `T` is guaranteed to be greater than, less than, or equal to the provided value of `T`. Example:
-
+This generates random values of `T` when the caller invokes one of its `NextLessThan(T)`, `NextLessThanOrEqualTo(T)`, `NextGreaterThan(T)`, or `NextGreaterThanOrEqualTo(T)` methods. Depending upon which method is used, the resultant value of `T` is guaranteed to be greater than, less than, or equal to the provided value of `T`. This interface inherits from `IDistinctGenerator<T>`. Example:
 ```cs
 using Peddler;
 
@@ -72,8 +71,8 @@ public static void Main(string[] args) {
 }
 ```
 
-## Implementations
-Peddler also includes implementations for many of the basic data types of the .NET Framework. While you can always create (or submit a pull request with) your own variant of any of these data types, the flexibility provided by the various constructors on each of these implementations will fill most use cases for raw, randomized data generation.
+## Base Implementations
+Peddler includes implementations for many of the basic data types of the .NET Framework. While you can always create (or submit a pull request with) your own variant of any of these data types, the flexibility provided by the various constructors on each of these implementations will fill most use cases for raw, randomized data generation.
 
 | Type | `IGenerator<T>` | `IDistinctGenerator<T>` | `IComparableGenerator<T>` | Notes |
 | ---- |:---------------:|:-----------------------:|:-------------------------:| ----- |
@@ -86,8 +85,18 @@ Peddler also includes implementations for many of the basic data types of the .N
 | [Int64](src/Peddler/Int64Generator.cs) | X | X | X |   |
 | [UInt64](src/Peddler/UInt64Generator.cs) | X | X | X |   |
 | [Guid](src/Peddler/GuidGenerator.cs) | X | X |   |   |
-| [DateTime](src/Peddler/DateTimeGenerator.cs) | X | X | X | Enforces consistent use of 'Kind' |
+| [DateTime](src/Peddler/DateTimeGenerator.cs) | X | X | X | Enforces consistent use of [`DateTimeKind`](https://msdn.microsoft.com/en-us/library/shx7s921.aspx) |
 | [String](src/Peddler/StringGenerator.cs) | X | X |   | Uses [`StringComparison.Ordinal`](https://msdn.microsoft.com/en-us/library/system.stringcomparison.aspx) rules |
+
+## Wrapper Implementations
+Peddler also includes implementations that wrap around base implementations in order to mutate their functionality. For example, a caller may want to periodically produce null, or convert value type `T` into `Nullable<T>`, without having to write a whole new generator. These implementations can wrap around the base implementation types to mutate their underlying behavior.
+
+| Type | `IGenerator<T>` | `IDistinctGenerator<T>` | `IComparableGenerator<T>` | Notes |
+| ---- |:---------------:|:-----------------------:|:-------------------------:| ----- |
+| [MaybeDefault<T>](src/Peddler/MaybeDefaultGenerator.cs) | X | | | Periodically returns `default(T)` based upon an injected percentage
+| [MaybeDefaultDistinct<T>](src/Peddler/MaybeDefaultDistinctGenerator.cs) | X | X | | Periodically returns `default(T)` based upon an injected percentage
+| [MaybeDefaultComparable<T>](src/Peddler/MaybeDefaultComparableGenerator.cs) | X | X | X | Periodically returns `default(T)` based upon an injected percentage
+
 
 ## Constraints
 

--- a/src/Peddler/DateTimeGenerator.cs
+++ b/src/Peddler/DateTimeGenerator.cs
@@ -49,6 +49,17 @@ namespace Peddler {
         public IEqualityComparer<DateTime> EqualityComparer { get; }
 
         /// <summary>
+        ///   The comparison used to determine if one <see cref="DateTime" />
+        ///   instance is earlier than, the same time as, or later than another
+        ///   <see cref="DateTime" /> instance.
+        /// </summary>
+        /// <remarks>
+        ///   It does take into account the <see cref="DateTimeKind" />
+        ///   restriction the <see cref="DateTimeGenerator"/> enforces.
+        /// </remarks>
+        public IComparer<DateTime> Comparer { get; }
+
+        /// <summary>
         ///   Instantiates a <see cref="DateTimeGenerator" /> that can create
         ///   <see cref="DateTime" /> values which range from
         ///   <see cref="DateTime.MinValue" /> to <see cref="DateTime.MaxValue" />.
@@ -123,7 +134,10 @@ namespace Peddler {
             this.Kind = low.Kind;
             this.Low = new DateTime(this.tickGenerator.Low, this.Kind);
             this.High = new DateTime(this.tickGenerator.High, this.Kind);
-            this.EqualityComparer = new KindSensitiveDateTimeComparer(this.Kind);
+
+            var comparer = new KindSensitiveDateTimeComparer(this.Kind);
+            this.EqualityComparer = comparer;
+            this.Comparer = comparer;
         }
 
         private DateTime NextImpl(Func<Int64> getNextTicks) {

--- a/src/Peddler/DateTimeGenerator.cs
+++ b/src/Peddler/DateTimeGenerator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace Peddler {
 
@@ -13,6 +14,12 @@ namespace Peddler {
     ///   the number of ticks used to represent its value.
     /// </remarks>
     public class DateTimeGenerator : IIntegralGenerator<DateTime> {
+
+        private static EqualityComparer<DateTime> defaultEqualityComparer { get; }
+
+        static DateTimeGenerator() {
+            defaultEqualityComparer = EqualityComparer<DateTime>.Default;
+        }
 
         private Int64Generator tickGenerator { get; }
 
@@ -36,6 +43,16 @@ namespace Peddler {
         ///   that can be created by this <see cref="DateTimeGenerator" />.
         /// </summary>
         public DateTime High { get; }
+
+        /// <summary>
+        ///   The comparison used to determine if two <see cref="DateTime" />
+        ///   instances are equal in value.
+        /// </summary>
+        /// <remarks>
+        ///   It does not take into account the <see cref="DateTimeKind" />
+        ///   restriction the <see cref="DateTimeGenerator"/> enforces.
+        /// </remarks>
+        public IEqualityComparer<DateTime> EqualityComparer { get; } = defaultEqualityComparer;
 
         /// <summary>
         ///   Instantiates a <see cref="DateTimeGenerator" /> that can create

--- a/src/Peddler/DateTimeGenerator.cs
+++ b/src/Peddler/DateTimeGenerator.cs
@@ -15,12 +15,6 @@ namespace Peddler {
     /// </remarks>
     public class DateTimeGenerator : IIntegralGenerator<DateTime> {
 
-        private static EqualityComparer<DateTime> defaultEqualityComparer { get; }
-
-        static DateTimeGenerator() {
-            defaultEqualityComparer = EqualityComparer<DateTime>.Default;
-        }
-
         private Int64Generator tickGenerator { get; }
 
         /// <summary>
@@ -49,10 +43,10 @@ namespace Peddler {
         ///   instances are equal in value.
         /// </summary>
         /// <remarks>
-        ///   It does not take into account the <see cref="DateTimeKind" />
+        ///   It does take into account the <see cref="DateTimeKind" />
         ///   restriction the <see cref="DateTimeGenerator"/> enforces.
         /// </remarks>
-        public IEqualityComparer<DateTime> EqualityComparer { get; } = defaultEqualityComparer;
+        public IEqualityComparer<DateTime> EqualityComparer { get; }
 
         /// <summary>
         ///   Instantiates a <see cref="DateTimeGenerator" /> that can create
@@ -129,6 +123,7 @@ namespace Peddler {
             this.Kind = low.Kind;
             this.Low = new DateTime(this.tickGenerator.Low, this.Kind);
             this.High = new DateTime(this.tickGenerator.High, this.Kind);
+            this.EqualityComparer = new KindSensitiveDateTimeComparer(this.Kind);
         }
 
         private DateTime NextImpl(Func<Int64> getNextTicks) {
@@ -139,8 +134,8 @@ namespace Peddler {
             if (other.Kind != this.Kind) {
                 throw new ArgumentException(
                     $"The {typeof(DateTimeKind).Name} of '{nameof(other)}' ({other.Kind:G}) " +
-                    $"did not match the '{typeof(DateTimeKind).Name}' of this " +
-                    $"typeof(typeof(DateTimeGenerator).Name) ({this.Kind:G}).",
+                    $"did not match the {typeof(DateTimeKind).Name} of this " +
+                    $"{typeof(DateTimeGenerator).Name} ({this.Kind:G}).",
                     nameof(other)
                 );
             }

--- a/src/Peddler/GuidGenerator.cs
+++ b/src/Peddler/GuidGenerator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace Peddler {
 
@@ -7,6 +8,15 @@ namespace Peddler {
     ///   for creating instances of <see cref="Guid" />.
     /// </summary>
     public class GuidGenerator : IDistinctGenerator<Guid> {
+
+        private static IEqualityComparer<Guid> defaultEqualityComparer { get; }
+
+        static GuidGenerator() {
+            defaultEqualityComparer = EqualityComparer<Guid>.Default;
+        }
+
+        /// <inheritdoc />
+        public IEqualityComparer<Guid> EqualityComparer { get; } = defaultEqualityComparer;
 
         /// <summary>
         ///   Generates a new, non-empty <see cref="Guid" /> instance.

--- a/src/Peddler/GuidGenerator.cs
+++ b/src/Peddler/GuidGenerator.cs
@@ -3,10 +3,10 @@ using System;
 namespace Peddler {
 
     /// <summary>
-    ///   A basic implementation of <see cref="IGenerator{Guid}" /> and
-    ///   <see cref="IDistinctGenerator{Guid}" /> for creating instances of <see cref="Guid" />.
+    ///   A basic implementation of <see cref="IDistinctGenerator{Guid}" />
+    ///   for creating instances of <see cref="Guid" />.
     /// </summary>
-    public class GuidGenerator : IGenerator<Guid>, IDistinctGenerator<Guid> {
+    public class GuidGenerator : IDistinctGenerator<Guid> {
 
         /// <summary>
         ///   Generates a new, non-empty <see cref="Guid" /> instance.

--- a/src/Peddler/IComparableGenerator.cs
+++ b/src/Peddler/IComparableGenerator.cs
@@ -6,7 +6,7 @@ namespace Peddler {
     ///   A common interface for generating values of type <typeparamref name="T"/> that are
     ///   greater than, less than, or equal to provided values of <typeparamref name="T"/>.
     /// </summary>
-    public interface IComparableGenerator<T> {
+    public interface IComparableGenerator<T> : IDistinctGenerator<T> {
 
         /// <summary>
         ///   Creates a new instance of <typeparamref name="T"/> that is

--- a/src/Peddler/IComparableGenerator.cs
+++ b/src/Peddler/IComparableGenerator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace Peddler {
 
@@ -7,6 +8,13 @@ namespace Peddler {
     ///   greater than, less than, or equal to provided values of <typeparamref name="T"/>.
     /// </summary>
     public interface IComparableGenerator<T> : IDistinctGenerator<T> {
+
+        /// <summary>
+        ///   A comparer that reflects the comparison used to determine if one instance
+        ///   of <typeparamref name="T" /> is considered less than, equal to, or greater
+        ///   than another instance of <typeparamref name="T" />.
+        /// </summary>
+        IComparer<T> Comparer { get; }
 
         /// <summary>
         ///   Creates a new instance of <typeparamref name="T"/> that is

--- a/src/Peddler/IDistinctGenerator.cs
+++ b/src/Peddler/IDistinctGenerator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace Peddler {
 
@@ -7,6 +8,12 @@ namespace Peddler {
     ///   that are distinct (i.e. "not equal to") values of <typeparamref name="T"/>.
     /// </summary>
     public interface IDistinctGenerator<T> : IGenerator<T> {
+
+        /// <summary>
+        ///   A comparer that reflects the comparison used to determine if two instances
+        ///   of <typeparamref name="T" /> are considered distinct for this generator.
+        /// </summary>
+        IEqualityComparer<T> EqualityComparer { get; }
 
         /// <summary>
         ///   Creates a new instance of <typeparamref name="T"/> that is

--- a/src/Peddler/IDistinctGenerator.cs
+++ b/src/Peddler/IDistinctGenerator.cs
@@ -6,7 +6,7 @@ namespace Peddler {
     ///   A common interface for generating values of type <typeparamref name="T"/>
     ///   that are distinct (i.e. "not equal to") values of <typeparamref name="T"/>.
     /// </summary>
-    public interface IDistinctGenerator<T>{
+    public interface IDistinctGenerator<T> : IGenerator<T> {
 
         /// <summary>
         ///   Creates a new instance of <typeparamref name="T"/> that is

--- a/src/Peddler/IIntegralGenerator.cs
+++ b/src/Peddler/IIntegralGenerator.cs
@@ -7,8 +7,7 @@ namespace Peddler {
     ///   represented as an integer, such as <see cref="Int32" />, <see cref="Byte" />,
     ///   <see cref="DateTime" /> (via ticks), or <see cref="System.Char" />.
     /// </summary>
-    public interface IIntegralGenerator<TIntegral> :
-        IGenerator<TIntegral>, IDistinctGenerator<TIntegral>, IComparableGenerator<TIntegral> {
+    public interface IIntegralGenerator<TIntegral> : IComparableGenerator<TIntegral> {
 
         /// <summary>
         ///   The inclusive, lower <typeparamref name="TIntegral" /> boundary for this generator.

--- a/src/Peddler/IntegralGenerator.cs
+++ b/src/Peddler/IntegralGenerator.cs
@@ -12,9 +12,11 @@ namespace Peddler {
         where TIntegral : struct, IEquatable<TIntegral>, IComparable<TIntegral> {
 
         private static EqualityComparer<TIntegral> defaultEqualityComparer { get; }
+        private static Comparer<TIntegral> defaultComparer { get; }
 
         static IntegralGenerator() {
             defaultEqualityComparer = EqualityComparer<TIntegral>.Default;
+            defaultComparer = Comparer<TIntegral>.Default;
         }
 
         /// <inheritdoc />
@@ -25,6 +27,9 @@ namespace Peddler {
 
         /// <inheritdoc />
         public IEqualityComparer<TIntegral> EqualityComparer { get; } = defaultEqualityComparer;
+
+        /// <inhericdoc />
+        public IComparer<TIntegral> Comparer { get; } = defaultComparer;
 
         /// <summary>
         ///   Instantiates an <see cref="IntegralGenerator{T}" /> that will create

--- a/src/Peddler/IntegralGenerator.cs
+++ b/src/Peddler/IntegralGenerator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace Peddler {
 
@@ -10,11 +11,20 @@ namespace Peddler {
     public abstract class IntegralGenerator<TIntegral> : IIntegralGenerator<TIntegral>
         where TIntegral : struct, IEquatable<TIntegral>, IComparable<TIntegral> {
 
+        private static EqualityComparer<TIntegral> defaultEqualityComparer { get; }
+
+        static IntegralGenerator() {
+            defaultEqualityComparer = EqualityComparer<TIntegral>.Default;
+        }
+
         /// <inheritdoc />
         public TIntegral Low { get; }
 
         /// <inheritdoc />
         public TIntegral High { get; }
+
+        /// <inheritdoc />
+        public IEqualityComparer<TIntegral> EqualityComparer { get; } = defaultEqualityComparer;
 
         /// <summary>
         ///   Instantiates an <see cref="IntegralGenerator{T}" /> that will create

--- a/src/Peddler/IntegralRandomExtensions.cs
+++ b/src/Peddler/IntegralRandomExtensions.cs
@@ -3,24 +3,24 @@ using System;
 namespace Peddler {
 
     /// <summary>
-    ///   A collection of extension methods for the <see cref="System.Random" /> class
-    ///   that provide the ability to generate any integral type in using APIs that
-    ///   are identical to <see cref="System.Random.Next(int, int)" />,
-    ///   <see cref="System.Random.Next(int)" />, and <see cref="System.Random.Next()" />.
+    ///   A collection of extension methods for the <see cref="Random" /> class
+    ///   that provide the ability to generate any integral type in using APIs
+    ///   that are identical to <see cref="Random.Next(int, int)" />,
+    ///   <see cref="Random.Next(int)" />, and <see cref="Random.Next()" />.
     /// </summary>
     public static class IntegralRandomExtensions {
 
         /// <summary>
-        ///   Creates a random <see cref="System.SByte" /> with a value between
-        ///   zero and <see cref="System.SByte.MaxValue" />.
+        ///   Creates a random <see cref="SByte" /> with a value between
+        ///   zero and <see cref="SByte.MaxValue" />.
         /// </summary>
         /// <param name="random">
-        ///   The <see cref="System.Random" /> instance being used via this extension method.
+        ///   The <see cref="Random" /> instance being used via this extension method.
         /// </param>
         /// <returns>
-        ///   The <see cref="System.SByte" /> that was randomly generated.
+        ///   The <see cref="SByte" /> that was randomly generated.
         /// </returns>
-        /// <exception cref="System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         ///   Thrown when <paramref name="random" /> is null.
         /// </exception>
         public static SByte NextSByte(this Random random) {
@@ -32,23 +32,23 @@ namespace Peddler {
         }
 
         /// <summary>
-        ///   Creates a random <see cref="System.SByte" /> with a value between
+        ///   Creates a random <see cref="SByte" /> with a value between
         ///   zero and <paramref name="maxValue" />.
         /// </summary>
         /// <param name="random">
-        ///   The <see cref="System.Random" /> instance being used via this extension method.
+        ///   The <see cref="Random" /> instance being used via this extension method.
         /// </param>
         /// <param name="maxValue">
-        ///   The upper, exclusive boundary for the <see cref="System.SByte" />
+        ///   The upper, exclusive boundary for the <see cref="SByte" />
         ///   that will be randomly generated.
         /// </param>
         /// <returns>
-        ///   The <see cref="System.SByte" /> that was randomly generated.
+        ///   The <see cref="SByte" /> that was randomly generated.
         /// </returns>
-        /// <exception cref="System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         ///   Thrown when <paramref name="random" /> is null.
         /// </exception>
-        /// <exception cref="System.ArgumentOutOfRangeException">
+        /// <exception cref="ArgumentOutOfRangeException">
         ///   Thrown when <paramref name="maxValue" /> is less than zero.
         /// </exception>
         public static SByte NextSByte(this Random random, SByte maxValue) {
@@ -67,27 +67,27 @@ namespace Peddler {
         }
 
         /// <summary>
-        ///   Creates a random <see cref="System.SByte" /> with a value between
+        ///   Creates a random <see cref="SByte" /> with a value between
         ///   <paramref name="minValue" /> and <paramref name="maxValue" />.
         /// </summary>
         /// <param name="random">
-        ///   The <see cref="System.Random" /> instance being used via this extension method.
+        ///   The <see cref="Random" /> instance being used via this extension method.
         /// </param>
         /// <param name="minValue">
-        ///   The lower, inclusive boundary for the <see cref="System.SByte" />
+        ///   The lower, inclusive boundary for the <see cref="SByte" />
         ///   that will be randomly generated.
         /// </param>
         /// <param name="maxValue">
-        ///   The upper, exclusive boundary for the <see cref="System.SByte" />
+        ///   The upper, exclusive boundary for the <see cref="SByte" />
         ///   that will be randomly generated.
         /// </param>
         /// <returns>
-        ///   The <see cref="System.SByte" /> that was randomly generated.
+        ///   The <see cref="SByte" /> that was randomly generated.
         /// </returns>
-        /// <exception cref="System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         ///   Thrown when <paramref name="random" /> is null.
         /// </exception>
-        /// <exception cref="System.ArgumentOutOfRangeException">
+        /// <exception cref="ArgumentOutOfRangeException">
         ///   Thrown when <paramref name="minValue" /> is greater than
         ///   <paramref name="maxValue" />.
         /// </exception>
@@ -107,16 +107,16 @@ namespace Peddler {
         }
 
         /// <summary>
-        ///   Creates a random <see cref="System.Byte" /> with a value between
-        ///   zero and <see cref="System.Byte.MaxValue" />.
+        ///   Creates a random <see cref="Byte" /> with a value between
+        ///   zero and <see cref="Byte.MaxValue" />.
         /// </summary>
         /// <param name="random">
-        ///   The <see cref="System.Random" /> instance being used via this extension method.
+        ///   The <see cref="Random" /> instance being used via this extension method.
         /// </param>
         /// <returns>
-        ///   The <see cref="System.Byte" /> that was randomly generated.
+        ///   The <see cref="Byte" /> that was randomly generated.
         /// </returns>
-        /// <exception cref="System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         ///   Thrown when <paramref name="random" /> is null.
         /// </exception>
         public static Byte NextByte(this Random random) {
@@ -128,20 +128,20 @@ namespace Peddler {
         }
 
         /// <summary>
-        ///   Creates a random <see cref="System.Byte" /> with a value between
+        ///   Creates a random <see cref="Byte" /> with a value between
         ///   zero and <paramref name="maxValue" />.
         /// </summary>
         /// <param name="random">
-        ///   The <see cref="System.Random" /> instance being used via this extension method.
+        ///   The <see cref="Random" /> instance being used via this extension method.
         /// </param>
         /// <param name="maxValue">
-        ///   The upper, exclusive boundary for the <see cref="System.Byte" />
+        ///   The upper, exclusive boundary for the <see cref="Byte" />
         ///   that will be randomly generated.
         /// </param>
         /// <returns>
-        ///   The <see cref="System.Byte" /> that was randomly generated.
+        ///   The <see cref="Byte" /> that was randomly generated.
         /// </returns>
-        /// <exception cref="System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         ///   Thrown when <paramref name="random" /> is null.
         /// </exception>
         public static Byte NextByte(this Random random, Byte maxValue) {
@@ -153,27 +153,27 @@ namespace Peddler {
         }
 
         /// <summary>
-        ///   Creates a random <see cref="System.Byte" /> with a value between
+        ///   Creates a random <see cref="Byte" /> with a value between
         ///   <paramref name="minValue" /> and <paramref name="maxValue" />.
         /// </summary>
         /// <param name="random">
-        ///   The <see cref="System.Random" /> instance being used via this extension method.
+        ///   The <see cref="Random" /> instance being used via this extension method.
         /// </param>
         /// <param name="minValue">
-        ///   The lower, inclusive boundary for the <see cref="System.Byte" />
+        ///   The lower, inclusive boundary for the <see cref="Byte" />
         ///   that will be randomly generated.
         /// </param>
         /// <param name="maxValue">
-        ///   The upper, exclusive boundary for the <see cref="System.Byte" />
+        ///   The upper, exclusive boundary for the <see cref="Byte" />
         ///   that will be randomly generated.
         /// </param>
         /// <returns>
-        ///   The <see cref="System.Byte" /> that was randomly generated.
+        ///   The <see cref="Byte" /> that was randomly generated.
         /// </returns>
-        /// <exception cref="System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         ///   Thrown when <paramref name="random" /> is null.
         /// </exception>
-        /// <exception cref="System.ArgumentOutOfRangeException">
+        /// <exception cref="ArgumentOutOfRangeException">
         ///   Thrown when <paramref name="minValue" /> is greater than
         ///   <paramref name="maxValue" />.
         /// </exception>
@@ -193,16 +193,16 @@ namespace Peddler {
         }
 
         /// <summary>
-        ///   Creates a random <see cref="System.Int16" /> with a value between
-        ///   zero and <see cref="System.Int16.MaxValue" />.
+        ///   Creates a random <see cref="Int16" /> with a value between
+        ///   zero and <see cref="Int16.MaxValue" />.
         /// </summary>
         /// <param name="random">
-        ///   The <see cref="System.Random" /> instance being used via this extension method.
+        ///   The <see cref="Random" /> instance being used via this extension method.
         /// </param>
         /// <returns>
-        ///   The <see cref="System.Int16" /> that was randomly generated.
+        ///   The <see cref="Int16" /> that was randomly generated.
         /// </returns>
-        /// <exception cref="System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         ///   Thrown when <paramref name="random" /> is null.
         /// </exception>
         public static Int16 NextInt16(this Random random) {
@@ -214,23 +214,23 @@ namespace Peddler {
         }
 
         /// <summary>
-        ///   Creates a random <see cref="System.Int16" /> with a value between
+        ///   Creates a random <see cref="Int16" /> with a value between
         ///   zero and <paramref name="maxValue" />.
         /// </summary>
         /// <param name="random">
-        ///   The <see cref="System.Random" /> instance being used via this extension method.
+        ///   The <see cref="Random" /> instance being used via this extension method.
         /// </param>
         /// <param name="maxValue">
-        ///   The upper, exclusive boundary for the <see cref="System.Int16" />
+        ///   The upper, exclusive boundary for the <see cref="Int16" />
         ///   that will be randomly generated.
         /// </param>
         /// <returns>
-        ///   The <see cref="System.Int16" /> that was randomly generated.
+        ///   The <see cref="Int16" /> that was randomly generated.
         /// </returns>
-        /// <exception cref="System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         ///   Thrown when <paramref name="random" /> is null.
         /// </exception>
-        /// <exception cref="System.ArgumentOutOfRangeException">
+        /// <exception cref="ArgumentOutOfRangeException">
         ///   Thrown when <paramref name="maxValue" /> is less than zero.
         /// </exception>
         public static Int16 NextInt16(this Random random, Int16 maxValue) {
@@ -249,27 +249,27 @@ namespace Peddler {
         }
 
         /// <summary>
-        ///   Creates a random <see cref="System.Int16" /> with a value between
+        ///   Creates a random <see cref="Int16" /> with a value between
         ///   <paramref name="minValue" /> and <paramref name="maxValue" />.
         /// </summary>
         /// <param name="random">
-        ///   The <see cref="System.Random" /> instance being used via this extension method.
+        ///   The <see cref="Random" /> instance being used via this extension method.
         /// </param>
         /// <param name="minValue">
-        ///   The lower, inclusive boundary for the <see cref="System.Int16" />
+        ///   The lower, inclusive boundary for the <see cref="Int16" />
         ///   that will be randomly generated.
         /// </param>
         /// <param name="maxValue">
-        ///   The upper, exclusive boundary for the <see cref="System.Int16" />
+        ///   The upper, exclusive boundary for the <see cref="Int16" />
         ///   that will be randomly generated.
         /// </param>
         /// <returns>
-        ///   The <see cref="System.Int16" /> that was randomly generated.
+        ///   The <see cref="Int16" /> that was randomly generated.
         /// </returns>
-        /// <exception cref="System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         ///   Thrown when <paramref name="random" /> is null.
         /// </exception>
-        /// <exception cref="System.ArgumentOutOfRangeException">
+        /// <exception cref="ArgumentOutOfRangeException">
         ///   Thrown when <paramref name="minValue" /> is greater than
         ///   <paramref name="maxValue" />.
         /// </exception>
@@ -289,16 +289,16 @@ namespace Peddler {
         }
 
         /// <summary>
-        ///   Creates a random <see cref="System.UInt16" /> with a value between
-        ///   zero and <see cref="System.UInt16.MaxValue" />.
+        ///   Creates a random <see cref="UInt16" /> with a value between
+        ///   zero and <see cref="UInt16.MaxValue" />.
         /// </summary>
         /// <param name="random">
-        ///   The <see cref="System.Random" /> instance being used via this extension method.
+        ///   The <see cref="Random" /> instance being used via this extension method.
         /// </param>
         /// <returns>
-        ///   The <see cref="System.UInt16" /> that was randomly generated.
+        ///   The <see cref="UInt16" /> that was randomly generated.
         /// </returns>
-        /// <exception cref="System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         ///   Thrown when <paramref name="random" /> is null.
         /// </exception>
         public static UInt16 NextUInt16(this Random random) {
@@ -310,20 +310,20 @@ namespace Peddler {
         }
 
         /// <summary>
-        ///   Creates a random <see cref="System.UInt16" /> with a value between
+        ///   Creates a random <see cref="UInt16" /> with a value between
         ///   zero and <paramref name="maxValue" />.
         /// </summary>
         /// <param name="random">
-        ///   The <see cref="System.Random" /> instance being used via this extension method.
+        ///   The <see cref="Random" /> instance being used via this extension method.
         /// </param>
         /// <param name="maxValue">
-        ///   The upper, exclusive boundary for the <see cref="System.UInt16" />
+        ///   The upper, exclusive boundary for the <see cref="UInt16" />
         ///   that will be randomly generated.
         /// </param>
         /// <returns>
-        ///   The <see cref="System.UInt16" /> that was randomly generated.
+        ///   The <see cref="UInt16" /> that was randomly generated.
         /// </returns>
-        /// <exception cref="System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         ///   Thrown when <paramref name="random" /> is null.
         /// </exception>
         public static UInt16 NextUInt16(this Random random, UInt16 maxValue) {
@@ -335,27 +335,27 @@ namespace Peddler {
         }
 
         /// <summary>
-        ///   Creates a random <see cref="System.UInt16" /> with a value between
+        ///   Creates a random <see cref="UInt16" /> with a value between
         ///   <paramref name="minValue" /> and <paramref name="maxValue" />.
         /// </summary>
         /// <param name="random">
-        ///   The <see cref="System.Random" /> instance being used via this extension method.
+        ///   The <see cref="Random" /> instance being used via this extension method.
         /// </param>
         /// <param name="minValue">
-        ///   The lower, inclusive boundary for the <see cref="System.UInt16" />
+        ///   The lower, inclusive boundary for the <see cref="UInt16" />
         ///   that will be randomly generated.
         /// </param>
         /// <param name="maxValue">
-        ///   The upper, exclusive boundary for the <see cref="System.UInt16" />
+        ///   The upper, exclusive boundary for the <see cref="UInt16" />
         ///   that will be randomly generated.
         /// </param>
         /// <returns>
-        ///   The <see cref="System.UInt16" /> that was randomly generated.
+        ///   The <see cref="UInt16" /> that was randomly generated.
         /// </returns>
-        /// <exception cref="System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         ///   Thrown when <paramref name="random" /> is null.
         /// </exception>
-        /// <exception cref="System.ArgumentOutOfRangeException">
+        /// <exception cref="ArgumentOutOfRangeException">
         ///   Thrown when <paramref name="minValue" /> is greater than
         ///   <paramref name="maxValue" />.
         /// </exception>
@@ -368,16 +368,16 @@ namespace Peddler {
         }
 
         /// <summary>
-        ///   Creates a random <see cref="System.UInt32" /> with a value between
-        ///   zero and <see cref="System.UInt32.MaxValue" />.
+        ///   Creates a random <see cref="UInt32" /> with a value between
+        ///   zero and <see cref="UInt32.MaxValue" />.
         /// </summary>
         /// <param name="random">
-        ///   The <see cref="System.Random" /> instance being used via this extension method.
+        ///   The <see cref="Random" /> instance being used via this extension method.
         /// </param>
         /// <returns>
-        ///   The <see cref="System.UInt32" /> that was randomly generated.
+        ///   The <see cref="UInt32" /> that was randomly generated.
         /// </returns>
-        /// <exception cref="System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         ///   Thrown when <paramref name="random" /> is null.
         /// </exception>
         public static UInt32 NextUInt32(this Random random) {
@@ -389,20 +389,20 @@ namespace Peddler {
         }
 
         /// <summary>
-        ///   Creates a random <see cref="System.UInt32" /> with a value between
+        ///   Creates a random <see cref="UInt32" /> with a value between
         ///   zero and <paramref name="maxValue" />.
         /// </summary>
         /// <param name="random">
-        ///   The <see cref="System.Random" /> instance being used via this extension method.
+        ///   The <see cref="Random" /> instance being used via this extension method.
         /// </param>
         /// <param name="maxValue">
-        ///   The upper, exclusive boundary for the <see cref="System.UInt32" />
+        ///   The upper, exclusive boundary for the <see cref="UInt32" />
         ///   that will be randomly generated.
         /// </param>
         /// <returns>
-        ///   The <see cref="System.UInt32" /> that was randomly generated.
+        ///   The <see cref="UInt32" /> that was randomly generated.
         /// </returns>
-        /// <exception cref="System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         ///   Thrown when <paramref name="random" /> is null.
         /// </exception>
         public static UInt32 NextUInt32(this Random random, UInt32 maxValue) {
@@ -414,27 +414,27 @@ namespace Peddler {
         }
 
         /// <summary>
-        ///   Creates a random <see cref="System.UInt32" /> with a value between
+        ///   Creates a random <see cref="UInt32" /> with a value between
         ///   <paramref name="minValue" /> and <paramref name="maxValue" />.
         /// </summary>
         /// <param name="random">
-        ///   The <see cref="System.Random" /> instance being used via this extension method.
+        ///   The <see cref="Random" /> instance being used via this extension method.
         /// </param>
         /// <param name="minValue">
-        ///   The lower, inclusive boundary for the <see cref="System.UInt32" />
+        ///   The lower, inclusive boundary for the <see cref="UInt32" />
         ///   that will be randomly generated.
         /// </param>
         /// <param name="maxValue">
-        ///   The upper, exclusive boundary for the <see cref="System.UInt32" />
+        ///   The upper, exclusive boundary for the <see cref="UInt32" />
         ///   that will be randomly generated.
         /// </param>
         /// <returns>
-        ///   The <see cref="System.UInt32" /> that was randomly generated.
+        ///   The <see cref="UInt32" /> that was randomly generated.
         /// </returns>
-        /// <exception cref="System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         ///   Thrown when <paramref name="random" /> is null.
         /// </exception>
-        /// <exception cref="System.ArgumentOutOfRangeException">
+        /// <exception cref="ArgumentOutOfRangeException">
         ///   Thrown when <paramref name="minValue" /> is greater than
         ///   <paramref name="maxValue" />.
         /// </exception>
@@ -447,16 +447,16 @@ namespace Peddler {
         }
 
         /// <summary>
-        ///   Creates a random <see cref="System.Int64" /> with a value between
-        ///   zero and <see cref="System.Int64.MaxValue" />.
+        ///   Creates a random <see cref="Int64" /> with a value between
+        ///   zero and <see cref="Int64.MaxValue" />.
         /// </summary>
         /// <param name="random">
-        ///   The <see cref="System.Random" /> instance being used via this extension method.
+        ///   The <see cref="Random" /> instance being used via this extension method.
         /// </param>
         /// <returns>
-        ///   The <see cref="System.Int64" /> that was randomly generated.
+        ///   The <see cref="Int64" /> that was randomly generated.
         /// </returns>
-        /// <exception cref="System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         ///   Thrown when <paramref name="random" /> is null.
         /// </exception>
         public static Int64 NextInt64(this Random random) {
@@ -468,23 +468,23 @@ namespace Peddler {
         }
 
         /// <summary>
-        ///   Creates a random <see cref="System.Int64" /> with a value between
+        ///   Creates a random <see cref="Int64" /> with a value between
         ///   zero and <paramref name="maxValue" />.
         /// </summary>
         /// <param name="random">
-        ///   The <see cref="System.Random" /> instance being used via this extension method.
+        ///   The <see cref="Random" /> instance being used via this extension method.
         /// </param>
         /// <param name="maxValue">
-        ///   The upper, exclusive boundary for the <see cref="System.Int64" />
+        ///   The upper, exclusive boundary for the <see cref="Int64" />
         ///   that will be randomly generated.
         /// </param>
         /// <returns>
-        ///   The <see cref="System.Int64" /> that was randomly generated.
+        ///   The <see cref="Int64" /> that was randomly generated.
         /// </returns>
-        /// <exception cref="System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         ///   Thrown when <paramref name="random" /> is null.
         /// </exception>
-        /// <exception cref="System.ArgumentOutOfRangeException">
+        /// <exception cref="ArgumentOutOfRangeException">
         ///   Thrown when <paramref name="maxValue" /> is less than zero.
         /// </exception>
         public static Int64 NextInt64(this Random random, Int64 maxValue) {
@@ -503,27 +503,27 @@ namespace Peddler {
         }
 
         /// <summary>
-        ///   Creates a random <see cref="System.Int64" /> with a value between
+        ///   Creates a random <see cref="Int64" /> with a value between
         ///   <paramref name="minValue" /> and <paramref name="maxValue" />.
         /// </summary>
         /// <param name="random">
-        ///   The <see cref="System.Random" /> instance being used via this extension method.
+        ///   The <see cref="Random" /> instance being used via this extension method.
         /// </param>
         /// <param name="minValue">
-        ///   The lower, inclusive boundary for the <see cref="System.Int64" />
+        ///   The lower, inclusive boundary for the <see cref="Int64" />
         ///   that will be randomly generated.
         /// </param>
         /// <param name="maxValue">
-        ///   The upper, exclusive boundary for the <see cref="System.Int64" />
+        ///   The upper, exclusive boundary for the <see cref="Int64" />
         ///   that will be randomly generated.
         /// </param>
         /// <returns>
-        ///   The <see cref="System.Int64" /> that was randomly generated.
+        ///   The <see cref="Int64" /> that was randomly generated.
         /// </returns>
-        /// <exception cref="System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         ///   Thrown when <paramref name="random" /> is null.
         /// </exception>
-        /// <exception cref="System.ArgumentOutOfRangeException">
+        /// <exception cref="ArgumentOutOfRangeException">
         ///   Thrown when <paramref name="minValue" /> is greater than
         ///   <paramref name="maxValue" />.
         /// </exception>
@@ -545,16 +545,16 @@ namespace Peddler {
         }
 
         /// <summary>
-        ///   Creates a random <see cref="System.UInt64" /> with a value between
-        ///   zero and <see cref="System.UInt64.MaxValue" />.
+        ///   Creates a random <see cref="UInt64" /> with a value between
+        ///   zero and <see cref="UInt64.MaxValue" />.
         /// </summary>
         /// <param name="random">
-        ///   The <see cref="System.Random" /> instance being used via this extension method.
+        ///   The <see cref="Random" /> instance being used via this extension method.
         /// </param>
         /// <returns>
-        ///   The <see cref="System.UInt64" /> that was randomly generated.
+        ///   The <see cref="UInt64" /> that was randomly generated.
         /// </returns>
-        /// <exception cref="System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         ///   Thrown when <paramref name="random" /> is null.
         /// </exception>
         public static UInt64 NextUInt64(this Random random) {
@@ -566,20 +566,20 @@ namespace Peddler {
         }
 
         /// <summary>
-        ///   Creates a random <see cref="System.UInt64" /> with a value between
+        ///   Creates a random <see cref="UInt64" /> with a value between
         ///   zero and <paramref name="maxValue" />.
         /// </summary>
         /// <param name="random">
-        ///   The <see cref="System.Random" /> instance being used via this extension method.
+        ///   The <see cref="Random" /> instance being used via this extension method.
         /// </param>
         /// <param name="maxValue">
-        ///   The upper, exclusive boundary for the <see cref="System.UInt64" />
+        ///   The upper, exclusive boundary for the <see cref="UInt64" />
         ///   that will be randomly generated.
         /// </param>
         /// <returns>
-        ///   The <see cref="System.UInt64" /> that was randomly generated.
+        ///   The <see cref="UInt64" /> that was randomly generated.
         /// </returns>
-        /// <exception cref="System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         ///   Thrown when <paramref name="random" /> is null.
         /// </exception>
         public static UInt64 NextUInt64(this Random random, UInt64 maxValue) {
@@ -591,27 +591,27 @@ namespace Peddler {
         }
 
         /// <summary>
-        ///   Creates a random <see cref="System.UInt64" /> with a value between
+        ///   Creates a random <see cref="UInt64" /> with a value between
         ///   <paramref name="minValue" /> and <paramref name="maxValue" />.
         /// </summary>
         /// <param name="random">
-        ///   The <see cref="System.Random" /> instance being used via this extension method.
+        ///   The <see cref="Random" /> instance being used via this extension method.
         /// </param>
         /// <param name="minValue">
-        ///   The lower, inclusive boundary for the <see cref="System.UInt64" />
+        ///   The lower, inclusive boundary for the <see cref="UInt64" />
         ///   that will be randomly generated.
         /// </param>
         /// <param name="maxValue">
-        ///   The upper, exclusive boundary for the <see cref="System.UInt64" />
+        ///   The upper, exclusive boundary for the <see cref="UInt64" />
         ///   that will be randomly generated.
         /// </param>
         /// <returns>
-        ///   The <see cref="System.UInt64" /> that was randomly generated.
+        ///   The <see cref="UInt64" /> that was randomly generated.
         /// </returns>
-        /// <exception cref="System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         ///   Thrown when <paramref name="random" /> is null.
         /// </exception>
-        /// <exception cref="System.ArgumentOutOfRangeException">
+        /// <exception cref="ArgumentOutOfRangeException">
         ///   Thrown when <paramref name="minValue" /> is greater than
         ///   <paramref name="maxValue" />.
         /// </exception>

--- a/src/Peddler/KindSensitiveDateTimeComparer.cs
+++ b/src/Peddler/KindSensitiveDateTimeComparer.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections.Generic;
+
+namespace Peddler {
+
+    /// <summary>
+    ///   An <see cref="Comparer{DateTime}" /> implementation that allows the caller
+    ///   to restricted by the <see cref="DateTimeKind" />
+    ///   caller to re
+    /// </summary>
+    public class KindSensitiveDateTimeComparer :
+        Comparer<DateTime>, IEqualityComparer<DateTime> {
+
+        /// <summary>
+        ///   The <see cref="DateTimeKind" /> that will be checked on all <see cref="DateTime" />
+        ///   objects compared with this <see cref="KindSensitiveDateTimeComparer" />. If a
+        ///   caller tries to compare <see cref="DateTime" /> instances that are not of this
+        ///   <see cref="DateTimeKind" />, an <see cref="ArgumentException" /> will be thrown.
+        /// </summary>
+        public DateTimeKind Kind { get; }
+
+        /// <summary>
+        ///   Creates a new instance of <see cref="KindSensitiveDateTimeComparer" /> that
+        ///   will only allow comparisons
+        /// </summary>
+        /// <param name="kind">
+        ///   The <see cref="DateTimeKind" /> this comparer will allow.
+        /// </param>
+        public KindSensitiveDateTimeComparer(DateTimeKind kind) {
+            this.Kind = kind;
+        }
+
+        /// <summary>
+        ///   Verifies that the left and right are of the same <see cref="DateTimeKind" />,
+        ///   then compares their internal ticks to determine if one is equal to the other.
+        /// </summary>
+        /// <param name="left">
+        ///   An instance of <see cref="DateTime" /> the caller wishes to compare with
+        ///   <paramref name="right" />.
+        /// </param>
+        /// <param name="right">
+        ///   An instance of <see cref="DateTime" /> the caller wishes to compare with
+        ///   <paramref name="left" />.
+        /// </param>
+        /// <returns>
+        ///   <code>true</code> if <paramref name="left" /> is the same instant
+        ///   as <paramref name="right" />. Otherwise, <code>false</code>.
+        /// </returns>
+        /// <exception cref="ArgumentException">
+        ///   Thrown when the <see cref="Kind" /> defined on this
+        ///   <see cref="KindSensitiveDateTimeComparer" /> is different than the
+        ///   <see cref="DateTimeKind" /> specified on the <paramref name="left" />
+        ///   or <paramref name="right" /> parameter.
+        /// </exception>
+        public virtual bool Equals(DateTime left, DateTime right) {
+            return this.Compare(left, right) == 0;
+        }
+
+        /// <summary>
+        ///   Gets the hash code that would be used to compare <see cref="DateTime" />
+        ///   instances to one another.
+        /// </summary>
+        /// <remarks>
+        ///   If two <see cref="DateTime" /> instances do not share the same hash code,
+        ///   they will always be considered unequal.
+        /// </remarks>
+        /// <param name="input">
+        ///   An instance of <see cref="DateTime" /> for which the caller wishes to
+        ///   retrieve the hash code.
+        /// </param>
+        /// <returns>
+        ///   The default hash code value for this <see cref="DateTime" />.
+        /// </returns>
+        /// <exception cref="ArgumentException">
+        ///   Thrown when the <see cref="Kind" /> defined on this
+        ///   <see cref="KindSensitiveDateTimeComparer" /> is different than the
+        ///   <see cref="DateTimeKind" /> specified on the <paramref name="input" />
+        ///   parameter.
+        /// </exception>
+        public virtual int GetHashCode(DateTime input) {
+            if (input.Kind != this.Kind) {
+                throw new ArgumentException(
+                    $"The {typeof(DateTimeKind).Name} of '{nameof(input)}' ({input.Kind:G}) " +
+                    $"does not match the {typeof(DateTimeKind).Name} of this " +
+                    $"{typeof(KindSensitiveDateTimeComparer).Name} ({this.Kind:G}).",
+                    nameof(input)
+                );
+            }
+
+            return input.GetHashCode();
+        }
+
+        /// <summary>
+        ///   Verifies that the left and right are of the same <see cref="DateTimeKind" />,
+        ///   then compares their internal ticks to determine if one is less than, greater
+        ///   than, or equal to the other.
+        /// </summary>
+        /// <param name="left">
+        ///   An instance of <see cref="DateTime" /> the caller wishes to compare with
+        ///   <paramref name="right" />.
+        /// </param>
+        /// <param name="right">
+        ///   An instance of <see cref="DateTime" /> the caller wishes to compare with
+        ///   <paramref name="left" />.
+        /// </param>
+        /// <returns>
+        ///   -1 if <paramref name="left" /> is earlier than <paramref name="right" />,
+        ///   0 if <paramref name="left" /> is the same instant as <paramref name="right" />,
+        ///   and 1 if <paramref name="left" /> is later than <paramref name="right" />.
+        /// </returns>
+        /// <exception cref="ArgumentException">
+        ///   Thrown when the <see cref="Kind" /> defined on this
+        ///   <see cref="KindSensitiveDateTimeComparer" /> is different than the
+        ///   <see cref="DateTimeKind" /> specified on the <paramref name="left" />
+        ///   or <paramref name="right" /> parameter.
+        /// </exception>
+        public override int Compare(DateTime left, DateTime right) {
+            if (left.Kind != this.Kind) {
+                throw new ArgumentException(
+                    $"The {typeof(DateTimeKind).Name} of '{nameof(left)}' ({left.Kind:G}) " +
+                    $"does not match the {typeof(DateTimeKind).Name} of this " +
+                    $"{typeof(KindSensitiveDateTimeComparer).Name} ({this.Kind:G}).",
+                    nameof(left)
+                );
+            }
+
+            if (right.Kind != this.Kind) {
+                throw new ArgumentException(
+                    $"The {typeof(DateTimeKind).Name} of '{nameof(right)}' ({right.Kind:G}) " +
+                    $"does not match the {typeof(DateTimeKind).Name} of this " +
+                    $"{typeof(KindSensitiveDateTimeComparer).Name} ({this.Kind:G}).",
+                    nameof(right)
+                );
+            }
+
+            return left.CompareTo(right);
+        }
+
+    }
+
+}

--- a/src/Peddler/MaybeDefaultComparableGenerator.cs
+++ b/src/Peddler/MaybeDefaultComparableGenerator.cs
@@ -1,0 +1,259 @@
+using System;
+using System.Collections.Generic;
+
+namespace Peddler {
+
+    /// <summary>
+    ///   An <see cref="IComparableGenerator{T}" /> that may provide the default
+    ///   value for <typeparamref name="T" /> in place of a value an inner
+    ///   <see cref="IComparableGenerator{T}" /> might otherwise provide.
+    /// </summary>
+    /// <remarks>
+    ///   This is most useful for periodically generating 'null' for
+    ///   <see cref="Nullable{T}" /> instances or for reference tyes.
+    /// </remarks>
+    public class MaybeDefaultComparableGenerator<T> :
+        MaybeDefaultDistinctGenerator<T>, IComparableGenerator<T> {
+
+        /// <inheritdoc />
+        public IComparer<T> Comparer {
+            get { return this.inner.Comparer; }
+        }
+
+        private IComparableGenerator<T> inner { get; }
+
+        /// <summary>
+        ///   Instantiates a <see cref="MaybeDefaultComparableGenerator{T}" /> that will
+        ///   provide the default value for <typeparamref name="T" /> 15% of the time.
+        ///   The other 85% of the time, it provides a value for <typeparamref name="T" />
+        ///   based upon the <paramref name="inner" /> <see cref="IComparableGenerator{T}" />.
+        /// </summary>
+        /// <remarks>
+        ///   When the default value for <typeparamref name="T" /> is not a valid value
+        ///   to return (for example, when <see cref="NextLessThan" /> is called with
+        ///   the default value of <typeparamref name="T" />), the percentage liklihood
+        ///   of returning the default value is ignored.
+        /// </remarks>
+        /// <param name="inner">
+        ///   An <see cref="IComparableGenerator{T}" /> implementation that will be used
+        ///   when the <see cref="MaybeDefaultComparableGenerator{T}" /> opts not to inject
+        ///   the default value for <typeparamref name="T" />.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///   Thrown when <paramref name="inner" /> is null.
+        /// </exception>
+        public MaybeDefaultComparableGenerator(IComparableGenerator<T> inner) :
+            base(inner) {
+
+            this.inner = inner;
+        }
+
+        /// <summary>
+        ///   Instantiates a <see cref="MaybeDefaultComparableGenerator{T}" /> that
+        ///   will provide the default value for <typeparamref name="T" /> by the
+        ///   percentage defined via the <paramname ref="percentage" /> parameter.
+        ///   If the <see cref="MaybeDefaultComparableGenerator{T}" /> opts not to provide
+        ///   the default value, it will provide a value for <typeparamref name="T" />
+        ///   based upon the <paramref name="inner" /> generator passed in instead.
+        /// </summary>
+        /// <param name="inner">
+        ///   An <see cref="IComparableGenerator{T}" /> implementation that will be used
+        ///   when the <see cref="MaybeDefaultComparableGenerator{T}" /> opts not
+        ///   to inject the default value for <typeparamref name="T" />.
+        /// </param>
+        /// <param name="percentage">
+        ///   A <see cref="Decimal" /> between 0.0 and 1.0 that represents a percentage
+        ///   (0% to 100%, respectively) of the time that the default value for
+        ///   <typeparamref name="T" /> will be used instead of a value created
+        ///   by the <paramref name="inner" /> <see cref="IComparableGenerator{T}" />.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///   Thrown when <paramref name="inner" /> is null.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   Thrown when <paramref name="percentage" /> is less than 0.0 or
+        ///   or greater than 1.0.
+        /// </exception>
+        public MaybeDefaultComparableGenerator(IComparableGenerator<T> inner, decimal percentage) :
+            base(inner, percentage) {
+
+            this.inner = inner;
+        }
+
+        /// <summary>
+        ///   Creates a new instance of <typeparamref name="T"/> that is
+        ///   greater than the value of <paramref name="other" />.
+        /// </summary>
+        /// <remarks>
+        ///   The percentage distribution of using the default value of
+        ///   <typeparamref name="T" /> will not be used if <paramref name="other" />
+        ///   is already greater than the default value of <typeparamref name="T" />,
+        ///   or if the inner generator is unable to provide a value and
+        ///   <paramref name="other" /> is not already greater than or equal to
+        ///   the default value of <typeparamref name="T" />.
+        /// </remarks>
+        /// <param name="other">
+        ///   An instance of <typeparamref name="T"/> that is a lower, exclusive boundary
+        ///   for any value that this <see cref="MaybeDefaultComparableGenerator{T}"/>
+        ///   may generate.
+        /// </param>
+        /// <returns>
+        ///   An instance of <typeparamref name="T"/> that is greater than
+        ///   <paramref name="other" />.
+        /// </returns>
+        /// <exception cref="UnableToGenerateValueException">
+        ///   Thrown when this <see cref="MaybeDefaultComparableGenerator{T}"/> is
+        ///   unable to generate a value that is greater than <paramref name="other" />.
+        /// </exception>
+        public T NextGreaterThan(T other) {
+            return this.NextByComparison(
+                other,
+                comparison => comparison > 0,
+                this.inner.NextGreaterThan
+            );
+        }
+
+        /// <summary>
+        ///   Creates a new instance of <typeparamref name="T"/> that is
+        ///   greater than or equal to the value of <paramref name="other" />.
+        /// </summary>
+        /// <remarks>
+        ///   <para>
+        ///     The percentage distribution of using the default value of
+        ///     <typeparamref name="T" /> will not be used if <paramref name="other" />
+        ///     is already greater than the default value of <typeparamref name="T" />,
+        ///     or if the inner generator is unable to provide a value and
+        ///     <paramref name="other" /> is not already greater than the default
+        ///     value of <typeparamref name="T" />.
+        ///   </para>
+        ///   <para>
+        ///     The range of values generated by this
+        ///     <see cref="MaybeDefaultComparableGenerator{T}"/> implementation may have
+        ///     a lower boundary that is greater than <paramref name="other" />. In that
+        ///     case, the value returned will always be greater than <paramref name="other" />.
+        ///   </para>
+        /// </remarks>
+        /// <param name="other">
+        ///   An instance of <typeparamref name="T"/> that is a lower, inclusive
+        ///   boundary for any value that this <see cref="MaybeDefaultComparableGenerator{T}"/>
+        ///   may generate.
+        /// </param>
+        /// <returns>
+        ///   An instance of <typeparamref name="T"/> that is greater than
+        ///   or equal to <paramref name="other" />.
+        /// </returns>
+        /// <exception cref="UnableToGenerateValueException">
+        ///   Thrown when this <see cref="MaybeDefaultComparableGenerator{T}"/> is unable
+        ///   to generate a value that is greater than or equal to <paramref name="other" />.
+        /// </exception>
+        public T NextGreaterThanOrEqualTo(T other) {
+            return this.NextByComparison(
+                other,
+                comparison => comparison >= 0,
+                this.inner.NextGreaterThanOrEqualTo
+            );
+        }
+
+        /// <summary>
+        ///   Creates a new instance of <typeparamref name="T"/> that is
+        ///   less than the value of <paramref name="other" />.
+        /// </summary>
+        /// <remarks>
+        ///   The percentage distribution of using the default value of
+        ///   <typeparamref name="T" /> will not be used if <paramref name="other" />
+        ///   is already less than the default value of <typeparamref name="T" />,
+        ///   or if the inner generator is unable to provide a value and
+        ///   <paramref name="other" /> is not already less than or equal to
+        ///   the default value of <typeparamref name="T" />.
+        /// </remarks>
+        /// <param name="other">
+        ///   An instance of <typeparamref name="T"/> that is an upper, exclusive boundary
+        ///   for any value that this <see cref="MaybeDefaultComparableGenerator{T}"/>
+        ///   may generate.
+        /// </param>
+        /// <returns>
+        ///   An instance of <typeparamref name="T"/> that is less than
+        ///   <paramref name="other" />.
+        /// </returns>
+        /// <exception cref="UnableToGenerateValueException">
+        ///   Thrown when this <see cref="MaybeDefaultComparableGenerator{T}"/> is
+        ///   unable to generate a value that is less than <paramref name="other" />.
+        /// </exception>
+        public T NextLessThan(T other) {
+            return this.NextByComparison(
+                other,
+                comparison => comparison < 0,
+                this.inner.NextLessThan
+            );
+        }
+
+        /// <summary>
+        ///   Creates a new instance of <typeparamref name="T"/> that is
+        ///   less than or equal to the value of <paramref name="other" />.
+        /// </summary>
+        /// <remarks>
+        ///   <para>
+        ///     The percentage distribution of using the default value of
+        ///     <typeparamref name="T" /> will not be used if <paramref name="other" />
+        ///     is already less than the default value of <typeparamref name="T" />,
+        ///     or if the inner generator is unable to provide a value and
+        ///     <paramref name="other" /> is not already less than the default
+        ///     value of <typeparamref name="T" />.
+        ///   </para>
+        ///   <para>
+        ///     The range of values generated by this
+        ///     <see cref="MaybeDefaultComparableGenerator{T}"/> implementation may have
+        ///     an upper boundary that is less than <paramref name="other" />. In that
+        ///     case, the value returned will always be less than <paramref name="other" />.
+        ///   </para>
+        /// </remarks>
+        /// <param name="other">
+        ///   An instance of <typeparamref name="T"/> that is an upper, inclusive boundary
+        ///   for any value that this <see cref="MaybeDefaultComparableGenerator{T}"/>
+        ///   may generate.
+        /// </param>
+        /// <returns>
+        ///   An instance of <typeparamref name="T" /> that is less than
+        ///   or equal to <paramref name="other" />.
+        /// </returns>
+        /// <exception cref="UnableToGenerateValueException">
+        ///   Thrown when this <see cref="MaybeDefaultComparableGenerator{T}"/> is unable
+        ///   to generate a value that is less than or equal to <paramref name="other" />.
+        /// </exception>
+        public T NextLessThanOrEqualTo(T other) {
+            return this.NextByComparison(
+                other,
+                comparison => comparison <= 0,
+                this.inner.NextLessThanOrEqualTo
+            );
+        }
+
+        private T NextByComparison(T other, Func<int, bool> isDefaultPossible, Func<T, T> next) {
+            var comparison = this.inner.Comparer.Compare(default(T), other);
+
+            if (!isDefaultPossible(comparison)) {
+                return next(other);
+            }
+
+            if (this.MaybeDefault()) {
+                return default(T);
+            }
+
+            try {
+
+                // We have already established that 'default(T)' is a valid value
+                // to return in this circumstance, so we will return it even though
+                // we didn't happen to pick it randomly this time.
+
+                // MaybeDefault() is a guideline based on the percentages.
+                // We will still return a valid value if that is at all possible.
+
+                return next(other);
+            } catch (UnableToGenerateValueException) {
+                return default(T);
+            }
+        }
+
+    }
+
+}

--- a/src/Peddler/MaybeDefaultDistinctGenerator.cs
+++ b/src/Peddler/MaybeDefaultDistinctGenerator.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+
+namespace Peddler {
+
+    /// <summary>
+    ///   An <see cref="IDistinctGenerator{T}" /> that may provide the default
+    ///   value for <typeparamref name="T" /> in place of a value an inner
+    ///   <see cref="IDistinctGenerator{T}" /> might otherwise provide.
+    /// </summary>
+    /// <remarks>
+    ///   This is most useful for periodically generating 'null' for
+    ///   <see cref="Nullable{T}" /> instances or for reference tyes.
+    /// </remarks>
+    public class MaybeDefaultDistinctGenerator<T> :
+        MaybeDefaultGenerator<T>, IDistinctGenerator<T> {
+
+        /// <inheritdoc />
+        public IEqualityComparer<T> EqualityComparer {
+            get { return this.inner.EqualityComparer; }
+        }
+
+        private IDistinctGenerator<T> inner { get; }
+
+        /// <summary>
+        ///   Instantiates a <see cref="MaybeDefaultDistinctGenerator{T}" /> that will
+        ///   provide the default value for <typeparamref name="T" /> 15% of the time.
+        ///   The other 85% of the time, it provides a value for <typeparamref name="T" />
+        ///   based upon the <paramref name="inner" /> <see cref="IDistinctGenerator{T}" />.
+        /// </summary>
+        /// <remarks>
+        ///   When the default value for <typeparamref name="T" /> is not a valid value
+        ///   to return (for example, when <see cref="NextDistinct" /> is called with
+        ///   the default value of <typeparamref name="T" />), the percentage liklihood
+        ///   of returning the default value is ignored.
+        /// </remarks>
+        /// <param name="inner">
+        ///   An <see cref="IDistinctGenerator{T}" /> implementation that will be used
+        ///   when the <see cref="MaybeDefaultDistinctGenerator{T}" /> opts not to inject
+        ///   the default value for <typeparamref name="T" />.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///   Thrown when <paramref name="inner" /> is null.
+        /// </exception>
+        public MaybeDefaultDistinctGenerator(IDistinctGenerator<T> inner) :
+            base(inner) {
+
+            this.inner = inner;
+        }
+
+        /// <summary>
+        ///   Instantiates an <see cref="MaybeDefaultDistinctGenerator{T}" /> that will
+        ///   provide the default value for <typeparamref name="T" /> by the
+        ///   percentage defined via the <paramname ref="percentage" /> parameter.
+        ///   If the <see cref="MaybeDefaultDistinctGenerator{T}" /> opts not to provide
+        ///   the default value, it will provide a value for <typeparamref name="T" />
+        ///   based upon the <paramref name="inner" /> generator passed in instead.
+        /// </summary>
+        /// <remarks>
+        ///   When the default value for <typeparamref name="T" /> is not a valid value
+        ///   to return (for example, when <see cref="NextDistinct" /> is called with
+        ///   the default value of <typeparamref name="T" />), the
+        ///   <paramref name="percentage" /> liklihood of returning the default value is
+        ///   ignored.
+        /// </remarks>
+        /// <param name="inner">
+        ///   An <see cref="IDistinctGenerator{T}" /> implementation that will be used
+        ///   when the <see cref="MaybeDefaultDistinctGenerator{T}" /> opts not to inject
+        ///   the default value for <typeparamref name="T" />.
+        /// </param>
+        /// <param name="percentage">
+        ///   A <see cref="Decimal" /> between 0.0 and 1.0 that represents a
+        ///   percentage (0% to 100%, respectively) of the time that the default
+        ///   value for <typeparamref name="T" /> will be used instead of a value
+        ///   created by the <paramref name="inner" /> <see cref="IDistinctGenerator{T}" />.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///   Thrown when <paramref name="inner" /> is null.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   Thrown when <paramref name="percentage" /> is less than 0.0 or
+        ///   or greater than 1.0.
+        /// </exception>
+        public MaybeDefaultDistinctGenerator(IDistinctGenerator<T> inner, decimal percentage) :
+            base(inner, percentage) {
+
+            this.inner = inner;
+        }
+
+        /// <summary>
+        ///   Creates a new instance of <typeparamref name="T"/> that is
+        ///   distinct from the value of <paramref name="other" />.
+        /// </summary>
+        /// <remarks>
+        ///   The percentage distribution of using the default value of
+        ///   <typeparamref name="T" /> will not be used if the value of
+        ///   <paramref name="other" /> is the default value of
+        ///   <typeparamref name="T" />, or if the inner generator is unable
+        ///   to provide a value and <paramref name="other" /> is not
+        ///   the default value of <typeparamref name="T" />.
+        /// </remarks>
+        /// <param name="other">
+        ///   An instance of <typeparamref name="T"/> that will be distinct from
+        ///   (i.e. "not equal to") the resultant value.
+        /// </param>
+        /// <returns>
+        ///   An instance of <typeparamref name="T"/> that is distinct (i.e. "not equal to")
+        ///   <paramref name="other" />.
+        /// </returns>
+        /// <exception cref="UnableToGenerateValueException">
+        ///   Thrown when this <see cref="IDistinctGenerator{T}"/> is unable to
+        ///   generate a value that is distinct from <paramref name="other" />.
+        /// </exception>
+        public T NextDistinct(T other) {
+            if (this.inner.EqualityComparer.Equals(other, default(T))) {
+                return this.inner.NextDistinct(other);
+            }
+
+            if (this.MaybeDefault()) {
+                return default(T);
+            }
+
+            try {
+
+                // If the inner IDistinctGenerator<T> is unable to
+                // generate a distinct value, but the value of "other"
+                // is not default(T), we can still fulfill the contract
+                // of the interface if by returning default(T).
+
+                return this.inner.NextDistinct(other);
+            } catch (UnableToGenerateValueException) {
+                return default(T);
+            }
+        }
+
+    }
+
+}

--- a/src/Peddler/MaybeDefaultGenerator.cs
+++ b/src/Peddler/MaybeDefaultGenerator.cs
@@ -1,0 +1,98 @@
+using System;
+
+namespace Peddler {
+
+    /// <summary>
+    ///   An <see cref="IGenerator{T}" /> that may provide the default
+    ///   value for <typeparamref name="T" /> in place of a value an inner
+    ///   <see cref="IGenerator{T}" /> might otherwise provide.
+    /// </summary>
+    /// <remarks>
+    ///   This is most useful for periodically generating 'null' for
+    ///   <see cref="Nullable{T}" /> instances or for reference tyes.
+    /// </remarks>
+    public class MaybeDefaultGenerator<T> : IGenerator<T> {
+
+        private Random random { get; } = new Random();
+        private IGenerator<T> inner { get; }
+        private decimal percentage { get; }
+
+        /// <summary>
+        ///   Instantiates a <see cref="MaybeDefaultGenerator{T}" /> that will provide
+        ///   the default value for <typeparamref name="T" /> 15% of the time.
+        ///   The other 85% of the time, it provides a value for <typeparamref name="T" />
+        ///   based upon the <paramref name="inner" /> <see cref="IGenerator{T}" />.
+        /// </summary>
+        /// <param name="inner">
+        ///   An <see cref="IGenerator{T}" /> implementation that will be used
+        ///   when the <see cref="MaybeDefaultGenerator{T}" /> opts not to inject
+        ///   the default value for <typeparamref name="T" />.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///   Thrown when <paramref name="inner" /> is null.
+        /// </exception>
+        public MaybeDefaultGenerator(IGenerator<T> inner) :
+            this(inner, 0.15m) {}
+
+        /// <summary>
+        ///   Instantiates a <see cref="MaybeDefaultGenerator{T}" /> that will
+        ///   provide the default value for <typeparamref name="T" /> by the
+        ///   percentage defined via the <paramname ref="percentage" /> parameter.
+        ///   If the <see cref="MaybeDefaultGenerator{T}" /> opts not to provide
+        ///   the default value, it will provide a value for <typeparamref name="T" />
+        ///   based upon the <paramref name="inner" /> generator passed in instead.
+        /// </summary>
+        /// <param name="inner">
+        ///   An <see cref="IGenerator{T}" /> implementation that will be used
+        ///   when the <see cref="MaybeDefaultGenerator{T}" /> opts not to inject
+        ///   the default value for <typeparamref name="T" />.
+        /// </param>
+        /// <param name="percentage">
+        ///   A <see cref="Decimal" /> between 0.0 and 1.0 that represents a
+        ///   percentage (0% to 100%, respectively) of the time that the default
+        ///   value for <typeparamref name="T" /> will be used instead of a value
+        ///   created by the <paramref name="inner" /> <see cref="IGenerator{T}" />.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///   Thrown when <paramref name="inner" /> is null.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   Thrown when <paramref name="percentage" /> is less than 0.0 or
+        ///   or greater than 1.0.
+        /// </exception>
+        public MaybeDefaultGenerator(IGenerator<T> inner, decimal percentage) {
+            if (inner == null) {
+                throw new ArgumentNullException(nameof(inner));
+            }
+
+            if (percentage < 0m || percentage > 1.0m) {
+                throw new ArgumentOutOfRangeException(
+                    nameof(percentage),
+                    $"'{nameof(percentage)}' must be between 0.0 and 1.0"
+                );
+            }
+
+            this.inner = inner;
+            this.percentage = percentage;
+        }
+
+        /// <summary>
+        ///   Determines whether or not the default value of <typeparamref name="T" />
+        ///   should be returned instead of a value from the inner <see cref="IGenerator{T}" />.
+        /// </summary>
+        protected bool MaybeDefault() {
+            return (percentage - ((decimal)this.random.NextDouble())) >= 0m;
+        }
+
+        /// <inheritdoc />
+        public T Next() {
+            if (this.MaybeDefault()) {
+                return default(T);
+            }
+
+            return this.inner.Next();
+        }
+
+    }
+
+}

--- a/src/Peddler/StringGenerator.cs
+++ b/src/Peddler/StringGenerator.cs
@@ -11,7 +11,13 @@ namespace Peddler {
     /// </summary>
     public class StringGenerator : IDistinctGenerator<String> {
 
-        private static ISet<Char> defaultCharacters { get; } = CharacterSets.AsciiPrintable;
+        private static ISet<Char> defaultCharacters { get; }
+        private static StringComparer defaultComparer { get; }
+
+        static StringGenerator() {
+            defaultCharacters = CharacterSets.AsciiPrintable;
+            defaultComparer = StringComparer.Ordinal;
+        }
 
         private Random random { get; } = new Random();
         private char[] charactersLookup { get; }
@@ -33,6 +39,9 @@ namespace Peddler {
         ///   will utilize from when creating instances of <see cref="String" />.
         /// </summary>
         public ISet<Char> Characters { get; }
+
+        /// <inheritdoc />
+        public IEqualityComparer<String> EqualityComparer { get; } = defaultComparer;
 
         /// <summary>
         ///   Instantiates a <see cref="StringGenerator" /> that can create
@@ -273,11 +282,7 @@ namespace Peddler {
         ///   <see cref="Characters" /> property.
         /// </exception>
         public String NextDistinct(String other) {
-            if (other == null) {
-                throw new ArgumentNullException(nameof(other));
-            }
-
-            if (other.Length < this.Minimum || other.Length > this.Maximum) {
+            if (other == null || other.Length < this.Minimum || other.Length > this.Maximum) {
 
                 // In this context, we couldn't generate a matching string if we wanted to,
 

--- a/src/Peddler/StringGenerator.cs
+++ b/src/Peddler/StringGenerator.cs
@@ -9,7 +9,7 @@ namespace Peddler {
     /// <summary>
     ///   A generator for non-nullable strings of various lengths and characters.
     /// </summary>
-    public class StringGenerator : IGenerator<String>, IDistinctGenerator<String> {
+    public class StringGenerator : IDistinctGenerator<String> {
 
         private static ISet<Char> defaultCharacters { get; } = CharacterSets.AsciiPrintable;
 

--- a/test/Peddler.Tests/DateTimeGeneratorTests.cs
+++ b/test/Peddler.Tests/DateTimeGeneratorTests.cs
@@ -160,6 +160,35 @@ namespace Peddler {
             );
         }
 
+        [Fact]
+        public void EqualityComparer_MismatchedKind() {
+            var date = DateTime.SpecifyKind(DateTime.Now, DateTimeKind.Local);
+            var generator = new DateTimeGenerator();
+
+            Assert.NotEqual(date.Kind, generator.Kind);
+
+            var comparer = generator.EqualityComparer;
+            Assert.Throws<ArgumentException>(
+                () => generator.EqualityComparer.Equals(date, date)
+            );
+
+            Assert.Throws<ArgumentException>(
+                () => generator.EqualityComparer.GetHashCode(date)
+            );
+        }
+
+        [Fact]
+        public void Comparer_MismatchedKind() {
+            var date = DateTime.SpecifyKind(DateTime.Now, DateTimeKind.Local);
+            var generator = new DateTimeGenerator();
+
+            Assert.NotEqual(date.Kind, generator.Kind);
+
+            var comparer = generator.EqualityComparer;
+            Assert.Throws<ArgumentException>(
+                () => generator.Comparer.Compare(date, date)
+            );
+        }
 
     }
 

--- a/test/Peddler.Tests/DefaultGenerator.cs
+++ b/test/Peddler.Tests/DefaultGenerator.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+
+namespace Peddler {
+
+    public class DefaultGenerator<T> : IComparableGenerator<T> {
+
+        public IEqualityComparer<T> EqualityComparer {
+            get { return EqualityComparer<T>.Default; }
+        }
+
+        public IComparer<T> Comparer {
+            get { return Comparer<T>.Default; }
+        }
+
+        public T Next() {
+            return default(T);
+        }
+
+        public T NextDistinct(T other) {
+            return this.NextImpl(other, comparison => comparison != 0);
+        }
+
+        public T NextGreaterThan(T other) {
+            return this.NextImpl(other, comparison => comparison > 0);
+        }
+
+        public T NextGreaterThanOrEqualTo(T other) {
+            return this.NextImpl(other, comparison => comparison >= 0);
+        }
+
+        public T NextLessThan(T other) {
+            return this.NextImpl(other, comparison => comparison < 0);
+        }
+
+        public T NextLessThanOrEqualTo(T other) {
+            return this.NextImpl(other, comparison => comparison <= 0);
+        }
+
+        private T NextImpl(T other, Func<int, bool> isDefaultOk) {
+            if (isDefaultOk(this.Comparer.Compare(default(T), other))) {
+                return default(T);
+            }
+
+            throw new UnableToGenerateValueException();
+        }
+
+    }
+
+}

--- a/test/Peddler.Tests/FakeClass.cs
+++ b/test/Peddler.Tests/FakeClass.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+
+namespace Peddler {
+
+    public class FakeClass : IEquatable<FakeClass>, IComparable<FakeClass> {
+
+        public int Value { get; }
+
+        public FakeClass(int value) {
+            this.Value = value;
+        }
+
+        public override int GetHashCode() {
+            return this.Value.GetHashCode();
+        }
+
+        public override bool Equals(Object that) {
+            return this.Equals(that as FakeClass);
+        }
+
+        public bool Equals(FakeClass that) {
+            return that != null
+                && this.Value == that.Value;
+        }
+
+        public int CompareTo(FakeClass other) {
+            if (other == null) {
+                return 1;
+            }
+
+            return this.Value.CompareTo(other.Value);
+        }
+
+        public override String ToString() {
+            return $"{{ '{nameof(Value)}': {this.Value:N0} }}";
+        }
+
+    }
+
+}

--- a/test/Peddler.Tests/FakeClassGenerator.cs
+++ b/test/Peddler.Tests/FakeClassGenerator.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace Peddler {
+
+    public class FakeClassGenerator : FakeGeneratorBase<FakeClass> {
+
+        public FakeClassGenerator() :
+            base() {}
+
+        public FakeClassGenerator(IComparableGenerator<int> generator) :
+            base(generator) {}
+
+        protected override FakeClass CreateFake(int value) {
+            return new FakeClass(value);
+        }
+
+        protected override int GetValue(FakeClass fake) {
+            if (fake == null) {
+                throw new ArgumentNullException(nameof(fake));
+            }
+
+            return fake.Value;
+        }
+
+    }
+
+}

--- a/test/Peddler.Tests/FakeGeneratorBase.cs
+++ b/test/Peddler.Tests/FakeGeneratorBase.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Collections.Generic;
+
+namespace Peddler {
+
+    public abstract class FakeGeneratorBase<TFake> : IComparableGenerator<TFake> {
+
+        public IEqualityComparer<TFake> EqualityComparer {
+            get { return EqualityComparer<TFake>.Default; }
+        }
+
+        public IComparer<TFake> Comparer {
+            get { return Comparer<TFake>.Default; }
+        }
+
+        private IComparableGenerator<int> generator { get; }
+
+        protected FakeGeneratorBase() :
+            this(new Int32Generator(-10, 10)) {}
+
+        protected FakeGeneratorBase(IComparableGenerator<int> generator) {
+            if (generator == null) {
+                throw new ArgumentNullException(nameof(generator));
+            }
+
+            this.generator = generator;
+        }
+
+        protected abstract TFake CreateFake(int value);
+        protected abstract int GetValue(TFake fake);
+
+        public TFake Next() {
+            return this.CreateFake(generator.Next());
+        }
+
+        public TFake NextDistinct(TFake other) {
+            return NextImpl(
+                other,
+                comparison => comparison != 0,
+                generator.NextDistinct
+            );
+        }
+
+        public TFake NextLessThan(TFake other) {
+            return NextImpl(
+                other,
+                comparison => comparison < 0,
+                generator.NextLessThan
+            );
+        }
+
+        public TFake NextLessThanOrEqualTo(TFake other) {
+            return NextImpl(
+                other,
+                comparison => comparison <= 0,
+                generator.NextLessThanOrEqualTo
+            );
+        }
+
+        public TFake NextGreaterThan(TFake other) {
+            return NextImpl(
+                other,
+                comparison => comparison > 0,
+                generator.NextGreaterThan
+            );
+        }
+
+        public TFake NextGreaterThanOrEqualTo(TFake other) {
+            return NextImpl(
+                other,
+                comparison => comparison >= 0,
+                generator.NextGreaterThanOrEqualTo
+            );
+        }
+
+        private TFake NextImpl(
+            TFake other,
+            Func<int, bool> isNonNullValueOk,
+            Func<int, int> nextImpl) {
+
+            if (other == null) {
+                var fake = this.Next();
+                var comparison = this.Comparer.Compare(fake, other);
+
+                if (!isNonNullValueOk(comparison)) {
+                    throw new UnableToGenerateValueException(
+                        $"Cannot generate {typeof(TFake).Name} when {nameof(other)} is null.",
+                        nameof(other)
+                    );
+                }
+
+                return fake;
+            }
+
+            return this.CreateFake(nextImpl(this.GetValue(other)));
+        }
+
+    }
+}

--- a/test/Peddler.Tests/FakeStruct.cs
+++ b/test/Peddler.Tests/FakeStruct.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+
+namespace Peddler {
+
+    public struct FakeStruct : IEquatable<FakeStruct>, IComparable<FakeStruct> {
+
+        public int Value { get; set; }
+
+        public override int GetHashCode() {
+            return this.Value.GetHashCode();
+        }
+
+        public override bool Equals(Object that) {
+            if (that is FakeStruct) {
+                return this.Equals((FakeStruct)that);
+            }
+
+            return false;
+        }
+
+        public bool Equals(FakeStruct that) {
+            return this.Value == that.Value;
+        }
+
+        public int CompareTo(FakeStruct other) {
+            return this.Value.CompareTo(other.Value);
+        }
+
+        public override String ToString() {
+            return $"{{ '{nameof(Value)}': {this.Value:N0} }}";
+        }
+
+    }
+
+}

--- a/test/Peddler.Tests/FakeStructGenerator.cs
+++ b/test/Peddler.Tests/FakeStructGenerator.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace Peddler {
+
+    public class FakeStructGenerator : FakeGeneratorBase<FakeStruct> {
+
+        public FakeStructGenerator() :
+            base() {}
+
+        public FakeStructGenerator(IComparableGenerator<int> generator) :
+            base(generator) {}
+
+        protected override FakeStruct CreateFake(int value) {
+            return new FakeStruct { Value = value };
+        }
+
+        protected override int GetValue(FakeStruct fake) {
+            return fake.Value;
+        }
+
+    }
+
+}

--- a/test/Peddler.Tests/GuidGeneratorTests.cs
+++ b/test/Peddler.Tests/GuidGeneratorTests.cs
@@ -12,9 +12,11 @@ namespace Peddler {
             var generator = new GuidGenerator();
 
             for (var attempt = 0; attempt < NUMBER_OF_ATTEMPTS; attempt++) {
-                Assert.NotEqual(Guid.Empty, generator.Next());
-            }
+                var value = generator.Next();
 
+                Assert.NotEqual(Guid.Empty, value);
+                Assert.True(generator.EqualityComparer.Equals(value, value));
+            }
         }
 
         [Fact]
@@ -27,6 +29,7 @@ namespace Peddler {
 
                 Assert.NotEqual(Guid.Empty, distinct);
                 Assert.NotEqual(original, distinct);
+                Assert.False(generator.EqualityComparer.Equals(original, distinct));
             }
         }
 

--- a/test/Peddler.Tests/IntegralGeneratorTests.cs
+++ b/test/Peddler.Tests/IntegralGeneratorTests.cs
@@ -102,6 +102,7 @@ namespace Peddler {
 
                 AssertGreaterThanOrEqualTo(value, generator.Low);
                 AssertLessThan(value, generator.High);
+                Assert.True(generator.EqualityComparer.Equals(value, value));
             }
         }
 
@@ -126,6 +127,7 @@ namespace Peddler {
 
                 AssertGreaterThanOrEqualTo(value, low);
                 AssertLessThan(value, generator.High);
+                Assert.True(generator.EqualityComparer.Equals(value, value));
             }
         }
 
@@ -153,6 +155,7 @@ namespace Peddler {
 
                 AssertGreaterThanOrEqualTo(value, low);
                 AssertLessThan(value, high);
+                Assert.True(generator.EqualityComparer.Equals(value, value));
             }
         }
 
@@ -172,6 +175,7 @@ namespace Peddler {
             for (var attempt = 0; attempt < numberOfAttempts; attempt++) {
                 var nextValue = generator.NextDistinct(previousValue);
                 Assert.NotEqual(previousValue, nextValue);
+                Assert.False(generator.EqualityComparer.Equals(previousValue, nextValue));
                 previousValue = nextValue;
             }
         }
@@ -199,6 +203,7 @@ namespace Peddler {
 
                 AssertGreaterThanOrEqualTo(value, generator.Low);
                 AssertLessThan(value, generator.High);
+                Assert.False(generator.EqualityComparer.Equals(other, value));
             }
         }
 
@@ -214,6 +219,7 @@ namespace Peddler {
 
                 AssertGreaterThanOrEqualTo(value, generator.Low);
                 AssertLessThan(value, generator.High);
+                Assert.False(generator.EqualityComparer.Equals(other, value));
             }
         }
 

--- a/test/Peddler.Tests/IntegralGeneratorTests.cs
+++ b/test/Peddler.Tests/IntegralGeneratorTests.cs
@@ -269,6 +269,7 @@ namespace Peddler {
                 AssertGreaterThan(value, other);
                 AssertGreaterThanOrEqualTo(value, generator.Low);
                 AssertLessThan(value, generator.High);
+                Assert.True(generator.Comparer.Compare(other, value) < 0);
             }
         }
 
@@ -318,6 +319,7 @@ namespace Peddler {
                 AssertGreaterThanOrEqualTo(value, other);
                 AssertGreaterThanOrEqualTo(value, generator.Low);
                 AssertLessThan(value, generator.High);
+                Assert.True(generator.Comparer.Compare(other, value) <= 0);
             }
         }
 
@@ -366,6 +368,7 @@ namespace Peddler {
                 AssertLessThan(value, other);
                 AssertGreaterThanOrEqualTo(value, generator.Low);
                 AssertLessThan(value, generator.High);
+                Assert.True(generator.Comparer.Compare(other, value) > 0);
             }
         }
 
@@ -415,6 +418,7 @@ namespace Peddler {
                 AssertLessThanOrEqualTo(value, other);
                 AssertGreaterThanOrEqualTo(value, generator.Low);
                 AssertLessThan(value, generator.High);
+                Assert.True(generator.Comparer.Compare(other, value) >= 0);
             }
         }
 

--- a/test/Peddler.Tests/KindSensitiveDateTimeComparerTests.cs
+++ b/test/Peddler.Tests/KindSensitiveDateTimeComparerTests.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Peddler {
+
+    public class KindSensitiveDateTimeComparerTests {
+
+        private static IList<DateTimeKind> kinds { get; }
+        private static IGenerator<Int64> tickGenerator { get; }
+
+        static KindSensitiveDateTimeComparerTests() {
+            kinds = new DateTimeKind[] {
+                DateTimeKind.Unspecified,
+                DateTimeKind.Local,
+                DateTimeKind.Utc
+            };
+
+            tickGenerator = new Int64Generator(DateTime.MinValue.Ticks, DateTime.MaxValue.Ticks);
+        }
+
+        public static IEnumerable<object[]> Kinds {
+            get {
+                foreach (var kind in kinds) {
+                    yield return new object[] { kind };
+                }
+            }
+        }
+
+        public static IEnumerable<object[]> MismatchedKinds {
+            get {
+                foreach (var comparerKind in kinds) {
+                    foreach (var leftKind in kinds) {
+                        foreach (var rightKind in kinds) {
+                            if (leftKind == comparerKind && rightKind == comparerKind) {
+                                continue;
+                            }
+
+                            yield return new object[] { comparerKind, leftKind, rightKind };
+                        }
+                    }
+                }
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(MismatchedKinds))]
+        public void Equals_KindMismatch(
+            DateTimeKind comparerKind,
+            DateTimeKind leftKind,
+            DateTimeKind rightKind) {
+
+            var comparer = new KindSensitiveDateTimeComparer(comparerKind);
+            var left = new DateTime(tickGenerator.Next(), leftKind);
+            var right = new DateTime(tickGenerator.Next(), rightKind);
+
+            var exception = Assert.Throws<ArgumentException>(
+                () => comparer.Equals(left, right)
+            );
+
+            if (leftKind != comparerKind) {
+                Assert.Equal(
+                    $"The DateTimeKind of 'left' ({leftKind:G}) " +
+                    $"does not match the DateTimeKind of this " +
+                    $"KindSensitiveDateTimeComparer ({comparerKind:G})." +
+                    $"{Environment.NewLine}Parameter name: left",
+                    exception.Message
+                );
+            } else {
+                Assert.Equal(
+                    $"The DateTimeKind of 'right' ({rightKind:G}) " +
+                    $"does not match the DateTimeKind of this " +
+                    $"KindSensitiveDateTimeComparer ({comparerKind:G})." +
+                    $"{Environment.NewLine}Parameter name: right",
+                    exception.Message
+                );
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(Kinds))]
+        public void Equals_MatchingKinds(DateTimeKind kind) {
+            var comparer = new KindSensitiveDateTimeComparer(kind);
+            var original = new DateTime(DateTime.MinValue.Ticks, kind);
+
+            var same = new DateTime(DateTime.MinValue.Ticks, kind);
+            Assert.True(comparer.Equals(original, same));
+
+            var different = new DateTime(DateTime.MinValue.Ticks + 1, kind);
+            Assert.False(comparer.Equals(original, different));
+        }
+
+        [Theory]
+        [InlineData(DateTimeKind.Unspecified, DateTimeKind.Utc)]
+        [InlineData(DateTimeKind.Unspecified, DateTimeKind.Local)]
+        [InlineData(DateTimeKind.Utc, DateTimeKind.Unspecified)]
+        [InlineData(DateTimeKind.Utc, DateTimeKind.Local)]
+        [InlineData(DateTimeKind.Local, DateTimeKind.Unspecified)]
+        [InlineData(DateTimeKind.Local, DateTimeKind.Utc)]
+        public void GetHashCode_KindMismatch(DateTimeKind comparerKind, DateTimeKind inputKind) {
+            var comparer = new KindSensitiveDateTimeComparer(comparerKind);
+            var input = new DateTime(tickGenerator.Next(), inputKind);
+
+            var exception = Assert.Throws<ArgumentException>(
+                () => comparer.GetHashCode(input)
+            );
+
+            Assert.Equal(
+                $"The DateTimeKind of 'input' ({inputKind:G}) " +
+                $"does not match the DateTimeKind of this " +
+                $"KindSensitiveDateTimeComparer ({comparerKind:G})." +
+                $"{Environment.NewLine}Parameter name: input",
+                exception.Message
+            );
+        }
+
+        [Theory]
+        [MemberData(nameof(Kinds))]
+        public void GetHashCode_MatchingKinds(DateTimeKind kind) {
+            var comparer = new KindSensitiveDateTimeComparer(kind);
+            var hashed = new DateTime(tickGenerator.Next(), kind);
+
+            Assert.Equal(comparer.GetHashCode(hashed), hashed.GetHashCode());
+        }
+
+
+        [Theory]
+        [MemberData(nameof(MismatchedKinds))]
+        public void Compare_KindMismatch(
+            DateTimeKind comparerKind,
+            DateTimeKind leftKind,
+            DateTimeKind rightKind) {
+
+            var comparer = new KindSensitiveDateTimeComparer(comparerKind);
+            var left = new DateTime(tickGenerator.Next(), leftKind);
+            var right = new DateTime(tickGenerator.Next(), rightKind);
+
+            var exception = Assert.Throws<ArgumentException>(
+                () => comparer.Compare(left, right)
+            );
+
+            if (leftKind != comparerKind) {
+                Assert.Equal(
+                    $"The DateTimeKind of 'left' ({leftKind:G}) " +
+                    $"does not match the DateTimeKind of this " +
+                    $"KindSensitiveDateTimeComparer ({comparerKind:G})." +
+                    $"{Environment.NewLine}Parameter name: left",
+                    exception.Message
+                );
+            } else {
+                Assert.Equal(
+                    $"The DateTimeKind of 'right' ({rightKind:G}) " +
+                    $"does not match the DateTimeKind of this " +
+                    $"KindSensitiveDateTimeComparer ({comparerKind:G})." +
+                    $"{Environment.NewLine}Parameter name: right",
+                    exception.Message
+                );
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(Kinds))]
+        public void Compare_MatchingKinds(DateTimeKind kind) {
+            var comparer = new KindSensitiveDateTimeComparer(kind);
+            var original = new DateTime(DateTime.MinValue.Ticks + 100, kind);
+
+            var same = new DateTime(original.Ticks, kind);
+            Assert.Equal(0, comparer.Compare(original, same));
+
+            var later = new DateTime(original.Ticks + 1, kind);
+            Assert.Equal(-1, comparer.Compare(original, later));
+
+            var earlier = new DateTime(original.Ticks - 1, kind);
+            Assert.Equal(1, comparer.Compare(original, earlier));
+        }
+
+    }
+
+}

--- a/test/Peddler.Tests/MaybeDefaultComparableGeneratorTests.cs
+++ b/test/Peddler.Tests/MaybeDefaultComparableGeneratorTests.cs
@@ -1,0 +1,484 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Peddler {
+
+    public class MaybeDefaultComparableGeneratorTests : MaybeDefaultDistinctGeneratorTests {
+
+        protected sealed override IDistinctGenerator<T> MaybeDefaultDistinct<T>(
+            IComparableGenerator<T> inner) {
+
+            return this.MaybeDefaultComparable<T>(inner);
+        }
+
+        protected sealed override IDistinctGenerator<T> MaybeDefaultDistinct<T>(
+            IComparableGenerator<T> inner,
+            decimal percentage) {
+
+            return this.MaybeDefaultComparable<T>(inner, percentage);
+        }
+
+        protected virtual IComparableGenerator<T> MaybeDefaultComparable<T>(
+            IComparableGenerator<T> inner) {
+
+            return new MaybeDefaultComparableGenerator<T>(inner);
+        }
+
+        protected virtual IComparableGenerator<T> MaybeDefaultComparable<T>(
+            IComparableGenerator<T> inner,
+            decimal percentage) {
+
+            return new MaybeDefaultComparableGenerator<T>(inner, percentage);
+        }
+
+        [Theory]
+        [MemberData(nameof(DefaultReturningGenerators))]
+        public void NextLessThan_InnerReturnsDefault(Object inner) {
+            this.InvokeGenericMethod(
+                nameof(NextLessThan_InnerReturnsDefaultImpl),
+                inner
+            );
+        }
+
+        public void NextLessThan_InnerReturnsDefaultImpl<T>(
+            IComparableGenerator<T> inner) {
+
+            var generator = this.MaybeDefaultComparable<T>(inner);
+
+            Assert.Throws<UnableToGenerateValueException>(
+                () => generator.NextLessThan(default(T))
+            );
+        }
+
+        public static IEnumerable<object[]> IgnoredPercentages {
+            get {
+                yield return new object[] { 0m };
+                yield return new object[] { 0.5m };
+                yield return new object[] { 1m };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(IgnoredPercentages))]
+        public void NextLessThan_InnerFailsButDefaultOk_Struct(decimal percentage) {
+            var inner = new FakeStructGenerator(new Int32Generator(5, 10));
+            var generator = this.MaybeDefaultComparable(inner, percentage);
+
+            for (var attempt = 0; attempt < numberOfAttempts; attempt++) {
+
+                // 2 is less than the range of FakeStructGenerator,
+                // but greater then default (which is 0).
+
+                var value = generator.NextLessThan(new FakeStruct { Value = 2 });
+
+                Assert.Equal(default(FakeStruct), value);
+                Assert.True(generator.EqualityComparer.Equals(default(FakeStruct), value));
+                Assert.Equal(0, generator.Comparer.Compare(default(FakeStruct), value));
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(IgnoredPercentages))]
+        public void NextLessThan_InnerFailsButDefaultOk_Class(decimal percentage) {
+            var inner = new FakeClassGenerator(new Int32Generator(5, 10));
+            var generator = this.MaybeDefaultComparable(inner, percentage);
+
+            for (var attempt = 0; attempt < numberOfAttempts; attempt++) {
+
+                // 2 is less than the range of FakeClassGenerator,
+                // but greater then default (which is null).
+                // null is always considered "less" than non-null values.
+
+                var value = generator.NextLessThan(new FakeClass(2));
+
+                Assert.Equal(default(FakeClass), value);
+                Assert.True(generator.EqualityComparer.Equals(default(FakeClass), value));
+                Assert.Equal(0, generator.Comparer.Compare(default(FakeClass), value));
+            }
+        }
+
+        public static IEnumerable<object[]> NextLessThan_FiftyPercentOfDefault_Data {
+            get {
+                return new List<object[]> {
+                    new object[] {
+                        new FakeStructGenerator(new Int32Generator(2, 5)),
+                        new FakeStruct { Value = 3 }
+                    },
+                    new object[] {
+                        new FakeStructGenerator(new Int32Generator(2, 5)),
+                        new FakeStruct { Value = 5 }
+                    },
+                    new object[] {
+                        new FakeClassGenerator(new Int32Generator(2, 5)),
+                        new FakeClass(3)
+                    },
+                    new object[] {
+                        new FakeClassGenerator(new Int32Generator(2, 5)),
+                        new FakeClass(5)
+                    }
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(NextLessThan_FiftyPercentOfDefault_Data))]
+        public void NextLessThan_FiftyPercentOfDefault(Object inner, Object otherValue) {
+            this.InvokeGenericMethod(
+                nameof(NextLessThan_FiftyPercentOfDefaultImpl),
+                inner,
+                otherValue
+            );
+        }
+
+        public void NextLessThan_FiftyPercentOfDefaultImpl<T>(
+            IComparableGenerator<T> inner,
+            T otherValue) {
+
+            this.NextImpl_FiftyPercentOfDefaultImpl<T>(
+                inner,
+                otherValue,
+                generator => generator.NextLessThan
+            );
+        }
+
+        [Theory]
+        [MemberData(nameof(DefaultReturningGenerators))]
+        public void NextLessThanOrEqualTo_InnerReturnsDefault(Object inner) {
+            this.InvokeGenericMethod(
+                nameof(NextLessThanOrEqualTo_InnerReturnsDefaultImpl),
+                inner
+            );
+        }
+
+        public void NextLessThanOrEqualTo_InnerReturnsDefaultImpl<T>(
+            IComparableGenerator<T> inner) {
+
+            var generator = this.MaybeDefaultComparable<T>(inner);
+
+            for (var attempt = 0; attempt < numberOfAttempts; attempt++) {
+                var value = generator.NextLessThanOrEqualTo(default(T));
+
+                Assert.Equal(default(T), value);
+                Assert.True(generator.EqualityComparer.Equals(default(T), value));
+                Assert.Equal(0, generator.Comparer.Compare(default(T), value));
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(IgnoredPercentages))]
+        public void NextLessThanOrEqualTo_InnerFailsButDefaultOk_Struct(decimal percentage) {
+            var inner = new FakeStructGenerator(new Int32Generator(5, 10));
+            var generator = this.MaybeDefaultComparable(inner, percentage);
+
+            for (var attempt = 0; attempt < numberOfAttempts; attempt++) {
+
+                // 2 is less than the range of FakeStructGenerator,
+                // but greater then default (which is 0).
+
+                var value = generator.NextLessThanOrEqualTo(new FakeStruct { Value = 2 });
+
+                Assert.Equal(default(FakeStruct), value);
+                Assert.True(generator.EqualityComparer.Equals(default(FakeStruct), value));
+                Assert.Equal(0, generator.Comparer.Compare(default(FakeStruct), value));
+
+                // the default is consider equal to itself, so should return default(T)
+
+                value = generator.NextLessThanOrEqualTo(default(FakeStruct));
+
+                Assert.Equal(default(FakeStruct), value);
+                Assert.True(generator.EqualityComparer.Equals(default(FakeStruct), value));
+                Assert.Equal(0, generator.Comparer.Compare(default(FakeStruct), value));
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(IgnoredPercentages))]
+        public void NextLessThanOrEqualTo_InnerFailsButDefaultOk_Class(decimal percentage) {
+            var inner = new FakeClassGenerator(new Int32Generator(5, 10));
+            var generator = this.MaybeDefaultComparable(inner, percentage);
+
+            for (var attempt = 0; attempt < numberOfAttempts; attempt++) {
+
+                // 2 is less than the range of FakeClassGenerator,
+                // but greater then default (which is null).
+                // null is always considered "less" than non-null values.
+
+                var value = generator.NextLessThanOrEqualTo(new FakeClass(2));
+
+                Assert.Equal(default(FakeClass), value);
+                Assert.True(generator.EqualityComparer.Equals(default(FakeClass), value));
+                Assert.Equal(0, generator.Comparer.Compare(default(FakeClass), value));
+
+                // the default is consider equal to itself, so should return default(T)
+
+                value = generator.NextLessThanOrEqualTo(default(FakeClass));
+
+                Assert.Equal(default(FakeClass), value);
+                Assert.True(generator.EqualityComparer.Equals(default(FakeClass), value));
+                Assert.Equal(0, generator.Comparer.Compare(default(FakeClass), value));
+            }
+        }
+
+        public static IEnumerable<object[]> NextLessThanOrEqualTo_FiftyPercentOfDefault_Data {
+            get {
+                return new List<object[]> {
+                    new object[] {
+                        new FakeStructGenerator(new Int32Generator(2, 5)),
+                        new FakeStruct { Value = 3 }
+                    },
+                    new object[] {
+                        new FakeStructGenerator(new Int32Generator(2, 5)),
+                        new FakeStruct { Value = 5 }
+                    },
+                    new object[] {
+                        new FakeStructGenerator(new Int32Generator(2, 5)),
+                        new FakeStruct { Value = 2 }
+                    },
+                    new object[] {
+                        new FakeClassGenerator(new Int32Generator(2, 5)),
+                        new FakeClass(3)
+                    },
+                    new object[] {
+                        new FakeClassGenerator(new Int32Generator(2, 5)),
+                        new FakeClass(5)
+                    },
+                    new object[] {
+                        new FakeClassGenerator(new Int32Generator(2, 5)),
+                        new FakeClass(2)
+                    }
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(NextLessThanOrEqualTo_FiftyPercentOfDefault_Data))]
+        public void NextLessThanOrEqualTo_FiftyPercentOfDefault(Object inner, Object otherValue) {
+            this.InvokeGenericMethod(
+                nameof(NextLessThanOrEqualTo_FiftyPercentOfDefaultImpl),
+                inner,
+                otherValue
+            );
+        }
+
+        public void NextLessThanOrEqualTo_FiftyPercentOfDefaultImpl<T>(
+            IComparableGenerator<T> inner,
+            T otherValue) {
+
+            this.NextImpl_FiftyPercentOfDefaultImpl<T>(
+                inner,
+                otherValue,
+                generator => generator.NextLessThanOrEqualTo
+            );
+        }
+
+        [Theory]
+        [MemberData(nameof(DefaultReturningGenerators))]
+        public void NextGreaterThanOrEqualTo_InnerReturnsDefault(Object inner) {
+            this.InvokeGenericMethod(
+                nameof(NextGreaterThanOrEqualTo_InnerReturnsDefaultImpl),
+                inner
+            );
+        }
+
+        public void NextGreaterThanOrEqualTo_InnerReturnsDefaultImpl<T>(
+            IComparableGenerator<T> inner) {
+
+            var generator = this.MaybeDefaultComparable<T>(inner);
+
+            for (var attempt = 0; attempt < numberOfAttempts; attempt++) {
+                var value = generator.NextGreaterThanOrEqualTo(default(T));
+
+                Assert.Equal(default(T), value);
+                Assert.True(generator.EqualityComparer.Equals(default(T), value));
+                Assert.Equal(0, generator.Comparer.Compare(default(T), value));
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(IgnoredPercentages))]
+        public void NextGreaterThanOrEqualTo_InnerFailsButDefaultOk(decimal percentage) {
+            var inner = new FakeStructGenerator(new Int32Generator(-10, -5));
+            var generator = this.MaybeDefaultComparable(inner, percentage);
+
+            for (var attempt = 0; attempt < numberOfAttempts; attempt++) {
+
+                // -5 is less than the range of FakeStructGenerator,
+                // but greater then default (which is 0).
+
+                var value = generator.NextGreaterThanOrEqualTo(new FakeStruct { Value = -2 });
+
+                Assert.Equal(default(FakeStruct), value);
+                Assert.True(generator.EqualityComparer.Equals(default(FakeStruct), value));
+                Assert.Equal(0, generator.Comparer.Compare(default(FakeStruct), value));
+
+                // the default is consider equal to itself, so should return default(T)
+
+                value = generator.NextGreaterThanOrEqualTo(default(FakeStruct));
+
+                Assert.Equal(default(FakeStruct), value);
+                Assert.True(generator.EqualityComparer.Equals(default(FakeStruct), value));
+                Assert.Equal(0, generator.Comparer.Compare(default(FakeStruct), value));
+            }
+        }
+
+        public static IEnumerable<object[]> NextGreaterThanOrEqualTo_FiftyPercentOfDefault_Data {
+            get {
+                return new List<object[]> {
+                    new object[] {
+                        new FakeStructGenerator(new Int32Generator(-4, -1)),
+                        new FakeStruct { Value = -5 }
+                    },
+                    new object[] {
+                        new FakeStructGenerator(new Int32Generator(-4, -1)),
+                        new FakeStruct { Value = -3 }
+                    },
+                    new object[] {
+                        new FakeStructGenerator(new Int32Generator(-4, -1)),
+                        new FakeStruct { Value = -2 }
+                    }
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(NextGreaterThanOrEqualTo_FiftyPercentOfDefault_Data))]
+        public void NextGreaterThanOrEqualTo_FiftyPercentOfDefault(Object inner, Object otherValue) {
+            this.InvokeGenericMethod(
+                nameof(NextGreaterThanOrEqualTo_FiftyPercentOfDefaultImpl),
+                inner,
+                otherValue
+            );
+        }
+
+        public void NextGreaterThanOrEqualTo_FiftyPercentOfDefaultImpl<T>(
+            IComparableGenerator<T> inner,
+            T otherValue) {
+
+            this.NextImpl_FiftyPercentOfDefaultImpl<T>(
+                inner,
+                otherValue,
+                generator => generator.NextGreaterThanOrEqualTo
+            );
+        }
+
+        [Theory]
+        [MemberData(nameof(DefaultReturningGenerators))]
+        public void NextGreaterThan_InnerReturnsDefault(Object inner) {
+            this.InvokeGenericMethod(
+                nameof(NextGreaterThan_InnerReturnsDefaultImpl),
+                inner
+            );
+        }
+
+        public void NextGreaterThan_InnerReturnsDefaultImpl<T>(IComparableGenerator<T> inner) {
+            var generator = this.MaybeDefaultComparable<T>(inner);
+
+            Assert.Throws<UnableToGenerateValueException>(
+                () => generator.NextGreaterThan(default(T))
+            );
+        }
+
+        [Theory]
+        [MemberData(nameof(IgnoredPercentages))]
+        public void NextGreaterThan_InnerFailsButDefaultOk(decimal percentage) {
+            var inner = new FakeStructGenerator(new Int32Generator(-10, -5));
+            var generator = this.MaybeDefaultComparable(inner, percentage);
+
+            for (var attempt = 0; attempt < numberOfAttempts; attempt++) {
+
+                // -5 is less than the range of FakeStructGenerator,
+                // but greater then default (which is 0).
+
+                var value = generator.NextGreaterThan(new FakeStruct { Value = -2 });
+
+                Assert.Equal(default(FakeStruct), value);
+                Assert.True(generator.EqualityComparer.Equals(default(FakeStruct), value));
+                Assert.Equal(0, generator.Comparer.Compare(default(FakeStruct), value));
+            }
+        }
+
+        public static IEnumerable<object[]> NextGreaterThan_FiftyPercentOfDefault_Data {
+            get {
+                return new List<object[]> {
+                    new object[] {
+                        new FakeStructGenerator(new Int32Generator(-4, -1)),
+                        new FakeStruct { Value = -5 }
+                    },
+                    new object[] {
+                        new FakeStructGenerator(new Int32Generator(-4, -1)),
+                        new FakeStruct { Value = -3 }
+                    }
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(NextGreaterThan_FiftyPercentOfDefault_Data))]
+        public void NextGreaterThan_FiftyPercentOfDefault(Object inner, Object otherValue) {
+            this.InvokeGenericMethod(
+                nameof(NextGreaterThan_FiftyPercentOfDefaultImpl),
+                inner,
+                otherValue
+            );
+        }
+
+        public void NextGreaterThan_FiftyPercentOfDefaultImpl<T>(
+            IComparableGenerator<T> inner,
+            T otherValue) {
+
+            this.NextImpl_FiftyPercentOfDefaultImpl<T>(
+                inner,
+                otherValue,
+                generator => generator.NextGreaterThan
+            );
+        }
+
+        private void NextImpl_FiftyPercentOfDefaultImpl<T>(
+            IComparableGenerator<T> inner,
+            T otherValue,
+            Func<IComparableGenerator<T>, Func<T, T>> getNextImpl) {
+
+            const decimal percentage = 0.5m;
+
+            var generator = this.MaybeDefaultComparable<T>(inner, percentage);
+            var nextImpl = getNextImpl(generator);
+
+            var hasDefault = false;
+            var hasNonDefault = false;
+
+            for (var attempt = 0; attempt < extendedNumberOfAttempts; attempt++) {
+                var value = nextImpl(otherValue);
+
+                if (!hasDefault) {
+                    hasDefault = inner.EqualityComparer.Equals(value, default(T));
+                }
+
+                if (!hasNonDefault) {
+                    hasNonDefault = !inner.EqualityComparer.Equals(value, default(T));
+                }
+
+                if (hasDefault && hasNonDefault) {
+                    break;
+                }
+            }
+
+            Assert.True(
+                hasDefault,
+                $"After {extendedNumberOfAttempts:N0} attempts with a {percentage * 100}% " +
+                $"percentage chance of generating default values, the generator did not " +
+                $"generate a default value. The randomization approach is unbalanced."
+            );
+
+            Assert.True(
+                hasNonDefault,
+                $"After {extendedNumberOfAttempts:N0} attempts with a {percentage * 100}% " +
+                $"percentage chance of generating default values, the generator did not " +
+                $"generate a non-default value. The randomization approach is unbalanced."
+            );
+
+        }
+
+    }
+
+}

--- a/test/Peddler.Tests/MaybeDefaultDistinctGeneratorTests.cs
+++ b/test/Peddler.Tests/MaybeDefaultDistinctGeneratorTests.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Peddler {
+
+    public class MaybeDefaultDistinctGeneratorTests : MaybeDefaultGeneratorTests {
+
+        protected sealed override IGenerator<T> MaybeDefault<T>(
+            IComparableGenerator<T> inner) {
+
+            return this.MaybeDefaultDistinct<T>(inner);
+        }
+
+        protected sealed override IGenerator<T> MaybeDefault<T>(
+            IComparableGenerator<T> inner,
+            decimal percentage) {
+
+            return this.MaybeDefaultDistinct<T>(inner, percentage);
+        }
+
+        protected virtual IDistinctGenerator<T> MaybeDefaultDistinct<T>(
+            IComparableGenerator<T> inner) {
+
+            return new MaybeDefaultDistinctGenerator<T>(inner);
+        }
+
+        protected virtual IDistinctGenerator<T> MaybeDefaultDistinct<T>(
+            IComparableGenerator<T> inner,
+            decimal percentage) {
+
+            return new MaybeDefaultDistinctGenerator<T>(inner, percentage);
+        }
+
+        public static IEnumerable<object[]> FakeGenerators {
+            get {
+                return new List<object[]> {
+                    new object[] { new FakeStructGenerator(new Int32Generator(-10, -1)) },
+                    new object[] { new FakeStructGenerator(new Int32Generator(-10, 10)) },
+                    new object[] { new FakeStructGenerator(new Int32Generator(1, 10)) },
+                    new object[] { new FakeStructGenerator(new Int32Generator(0, 2)) },
+                    new object[] { new FakeClassGenerator() }
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(FakeGenerators))]
+        public void NextDistinct_InnerCanGenerateNonDefault(Object inner) {
+            this.InvokeGenericMethod(
+                nameof(NextDistinct_InnerCanGenerateNonDefaultImpl),
+                inner
+            );
+        }
+
+        public void NextDistinct_InnerCanGenerateNonDefaultImpl<T>(
+            IComparableGenerator<T> inner) {
+
+            var generator = this.MaybeDefaultDistinct<T>(inner);
+
+            for (var attempt = 0; attempt < numberOfAttempts; attempt++) {
+                var value = generator.NextDistinct(default(T));
+
+                Assert.NotEqual(default(T), value);
+                Assert.False(generator.EqualityComparer.Equals(default(T), value));
+            }
+        }
+
+        public static IEnumerable<object[]> DefaultReturningGenerators {
+            get {
+                return new List<object[]> {
+                    new object[] { new DefaultGenerator<Object>() },
+                    new object[] { new DefaultGenerator<int>() },
+                    new object[] { new DefaultGenerator<FakeClass>() },
+                    new object[] { new DefaultGenerator<FakeStruct>() }
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(DefaultReturningGenerators))]
+        public void NextDistinct_InnerOnlyReturnsDefault(Object inner) {
+            this.InvokeGenericMethod(
+                nameof(NextDistinct_InnerOnlyReturnsDefaultImpl),
+                inner
+            );
+        }
+
+        public void NextDistinct_InnerOnlyReturnsDefaultImpl<T>(IComparableGenerator<T> inner) {
+            var generator = this.MaybeDefaultDistinct<T>(inner);
+
+            Assert.Throws<UnableToGenerateValueException>(
+                () => generator.NextDistinct(default(T))
+            );
+        }
+
+        [Theory]
+        [MemberData(nameof(FakeGenerators))]
+        public void NextDistinct_FiftyPercentageOfDefault(Object inner) {
+            this.InvokeGenericMethod(
+                nameof(NextDistinct_FiftyPercentageOfDefaultImpl),
+                inner
+            );
+        }
+
+        public void NextDistinct_FiftyPercentageOfDefaultImpl<T>(
+            IComparableGenerator<T> inner) {
+
+            const decimal percentage = 0.5m;
+
+            var generator = this.MaybeDefaultDistinct<T>(inner, percentage);
+            var hasDefault = false;
+            var hasNonDefault = false;
+
+            for (var attempt = 0; attempt < extendedNumberOfAttempts; attempt++) {
+                var value = generator.NextDistinct(generator.Next());
+
+                if (!hasDefault) {
+                    hasDefault = inner.EqualityComparer.Equals(value, default(T));
+                }
+
+                if (!hasNonDefault) {
+                    hasNonDefault = !inner.EqualityComparer.Equals(value, default(T));
+                }
+
+                if (hasDefault && hasNonDefault) {
+                    break;
+                }
+            }
+
+            Assert.True(
+                hasDefault && hasNonDefault,
+                $"After {extendedNumberOfAttempts:N0} attempts with a {percentage * 100}% " +
+                $"percentage chance of generating default values, the generator did not " +
+                $"generate both a default and non-default value. The randomization approach " +
+                $"is unbalanced."
+            );
+        }
+
+    }
+
+}

--- a/test/Peddler.Tests/MaybeDefaultGeneratorTests.cs
+++ b/test/Peddler.Tests/MaybeDefaultGeneratorTests.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Peddler {
+
+    public class MaybeDefaultGeneratorTests {
+
+        private const int numberOfAttempts = 100;
+
+        protected virtual IGenerator<T> MaybeDefault<T>(IGenerator<T> inner) {
+            return new MaybeDefaultGenerator<T>(inner);
+        }
+
+        protected virtual IGenerator<T> MaybeDefault<T>(IGenerator<T> inner, decimal percentage) {
+            return new MaybeDefaultGenerator<T>(inner, percentage);
+        }
+
+        [Fact]
+        public void Constructor_NullInnerGenerator() {
+            IGenerator<Object> inner = null;
+
+            Assert.Throws<ArgumentNullException>(
+                () => this.MaybeDefault(inner)
+            );
+
+            Assert.Throws<ArgumentNullException>(
+                () => this.MaybeDefault(inner, 0.5m)
+            );
+        }
+
+        public static IEnumerable<object[]> Constructor_PercentageBelowZero_Data {
+            get {
+                yield return new object[] { -0.1m };
+                yield return new object[] { -1m };
+                yield return new object[] { Decimal.MinValue };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(Constructor_PercentageBelowZero_Data))]
+        public void Constructor_PercentageBelowZero(decimal percentage) {
+            var inner = new ObjectGenerator();
+
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => this.MaybeDefault(inner, percentage)
+            );
+        }
+
+        public static IEnumerable<object[]> Constructor_PercentageAboveOne_Data {
+            get {
+                yield return new object[] { 1.1m };
+                yield return new object[] { 2m };
+                yield return new object[] { Decimal.MaxValue };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(Constructor_PercentageAboveOne_Data))]
+        public void Constructor_PercentageAboveOne(decimal percentage) {
+            var inner = new ObjectGenerator();
+
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => this.MaybeDefault(inner, percentage)
+            );
+        }
+
+        [Fact]
+        public void Next_ZeroPercentageOfDefault() {
+            var generator = this.MaybeDefault(new ObjectGenerator(), 0m);
+
+            for (var attempt = 0; attempt < numberOfAttempts; attempt++) {
+                Assert.NotEqual(null, generator.Next());
+            }
+        }
+
+        [Fact]
+        public void Next_OneHundredPercentageOfDefault() {
+            var generator = this.MaybeDefault(new ObjectGenerator(), 1m);
+
+            for (var attempt = 0; attempt < numberOfAttempts; attempt++) {
+                Assert.Equal(null, generator.Next());
+            }
+        }
+
+        [Fact]
+        public void Next_FiftyPercentageOfDefault() {
+            const int maximumNumberOfAttempts = 1000;
+            const decimal percentage = 0.5m;
+
+            var generator = this.MaybeDefault(new ObjectGenerator(), percentage);
+            var hasNull = false;
+            var hasNonNull = false;
+
+            for (var attempt = 0; attempt < maximumNumberOfAttempts; attempt++) {
+                var value = generator.Next();
+
+                hasNull = hasNull || (value == null);
+                hasNonNull = hasNonNull || (value != null);
+
+                if (hasNull && hasNonNull) {
+                    break;
+                }
+            }
+
+            Assert.True(
+                hasNull && hasNonNull,
+                $"After {maximumNumberOfAttempts:N0} attempts with a {percentage * 100}% " +
+                $"percentage chance of generating default values, the generator did not " +
+                $"generate both a default and non-default value. The randomization approach " +
+                $"is unbalanced."
+            );
+        }
+
+        public class ObjectGenerator : IGenerator<Object> {
+
+            public Object Next() {
+                return new Object();
+            }
+
+        }
+
+    }
+
+}

--- a/test/Peddler.Tests/MaybeDefaultGeneratorTests.cs
+++ b/test/Peddler.Tests/MaybeDefaultGeneratorTests.cs
@@ -1,24 +1,40 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 using Xunit;
 
 namespace Peddler {
 
     public class MaybeDefaultGeneratorTests {
 
-        private const int numberOfAttempts = 100;
+        protected const int numberOfAttempts = 100;
+        protected const int extendedNumberOfAttempts = 10 * numberOfAttempts;
 
-        protected virtual IGenerator<T> MaybeDefault<T>(IGenerator<T> inner) {
+        protected virtual IGenerator<T> MaybeDefault<T>(IComparableGenerator<T> inner) {
             return new MaybeDefaultGenerator<T>(inner);
         }
 
-        protected virtual IGenerator<T> MaybeDefault<T>(IGenerator<T> inner, decimal percentage) {
+        protected virtual IGenerator<T> MaybeDefault<T>(
+            IComparableGenerator<T> inner,
+            decimal percentage) {
+
             return new MaybeDefaultGenerator<T>(inner, percentage);
+        }
+
+        public static IEnumerable<object[]> NonDefaultReturningGenerators {
+            get {
+                return new List<object[]> {
+                    new object[] { new FakeClassGenerator() },
+                    new object[] { new FakeStructGenerator(new Int32Generator(1, 10)) },
+                    new object[] { new FakeStructGenerator(new Int32Generator(-10, -1)) }
+                };
+            }
         }
 
         [Fact]
         public void Constructor_NullInnerGenerator() {
-            IGenerator<Object> inner = null;
+            IComparableGenerator<Object> inner = null;
 
             Assert.Throws<ArgumentNullException>(
                 () => this.MaybeDefault(inner)
@@ -40,7 +56,7 @@ namespace Peddler {
         [Theory]
         [MemberData(nameof(Constructor_PercentageBelowZero_Data))]
         public void Constructor_PercentageBelowZero(decimal percentage) {
-            var inner = new ObjectGenerator();
+            var inner = new FakeClassGenerator();
 
             Assert.Throws<ArgumentOutOfRangeException>(
                 () => this.MaybeDefault(inner, percentage)
@@ -58,66 +74,122 @@ namespace Peddler {
         [Theory]
         [MemberData(nameof(Constructor_PercentageAboveOne_Data))]
         public void Constructor_PercentageAboveOne(decimal percentage) {
-            var inner = new ObjectGenerator();
+            var inner = new FakeClassGenerator();
 
             Assert.Throws<ArgumentOutOfRangeException>(
                 () => this.MaybeDefault(inner, percentage)
             );
         }
 
-        [Fact]
-        public void Next_ZeroPercentageOfDefault() {
-            var generator = this.MaybeDefault(new ObjectGenerator(), 0m);
+        [Theory]
+        [MemberData(nameof(NonDefaultReturningGenerators))]
+        public void Next_ZeroPercentageOfDefault(Object inner) {
+            this.InvokeGenericMethod(nameof(Next_ZeroPercentageOfDefaultImpl), inner);
+        }
+
+        public void Next_ZeroPercentageOfDefaultImpl<T>(IComparableGenerator<T> inner) {
+            var generator = this.MaybeDefault<T>(inner, 0m);
 
             for (var attempt = 0; attempt < numberOfAttempts; attempt++) {
-                Assert.NotEqual(null, generator.Next());
+                Assert.NotEqual(default(T), generator.Next());
             }
         }
 
-        [Fact]
-        public void Next_OneHundredPercentageOfDefault() {
-            var generator = this.MaybeDefault(new ObjectGenerator(), 1m);
+        [Theory]
+        [MemberData(nameof(NonDefaultReturningGenerators))]
+        public void Next_OneHundredPercentageOfDefault(Object inner) {
+            this.InvokeGenericMethod(nameof(Next_OneHundredPercentageOfDefaultImpl), inner);
+        }
+
+        public void Next_OneHundredPercentageOfDefaultImpl<T>(FakeGeneratorBase<T> inner) {
+            var generator = this.MaybeDefault<T>(inner, 1m);
 
             for (var attempt = 0; attempt < numberOfAttempts; attempt++) {
-                Assert.Equal(null, generator.Next());
+                Assert.Equal(default(T), generator.Next());
             }
         }
 
-        [Fact]
-        public void Next_FiftyPercentageOfDefault() {
-            const int maximumNumberOfAttempts = 1000;
+        [Theory]
+        [MemberData(nameof(NonDefaultReturningGenerators))]
+        public void Next_FiftyPercentageOfDefault(Object inner) {
+            this.InvokeGenericMethod(nameof(Next_FiftyPercentageOfDefaultImpl), inner);
+        }
+
+        public void Next_FiftyPercentageOfDefaultImpl<T>(IComparableGenerator<T> inner) {
             const decimal percentage = 0.5m;
 
-            var generator = this.MaybeDefault(new ObjectGenerator(), percentage);
-            var hasNull = false;
-            var hasNonNull = false;
+            var generator = this.MaybeDefault<T>(inner, percentage);
+            var hasDefault = false;
+            var hasNonDefault = false;
 
-            for (var attempt = 0; attempt < maximumNumberOfAttempts; attempt++) {
+            for (var attempt = 0; attempt < extendedNumberOfAttempts; attempt++) {
                 var value = generator.Next();
 
-                hasNull = hasNull || (value == null);
-                hasNonNull = hasNonNull || (value != null);
+                if (!hasDefault) {
+                    hasDefault = inner.EqualityComparer.Equals(value, default(T));
+                }
 
-                if (hasNull && hasNonNull) {
+                if (!hasNonDefault) {
+                    hasNonDefault = !inner.EqualityComparer.Equals(value, default(T));
+                }
+
+                if (hasDefault && hasNonDefault) {
                     break;
                 }
             }
 
             Assert.True(
-                hasNull && hasNonNull,
-                $"After {maximumNumberOfAttempts:N0} attempts with a {percentage * 100}% " +
+                hasDefault && hasNonDefault,
+                $"After {extendedNumberOfAttempts:N0} attempts with a {percentage * 100}% " +
                 $"percentage chance of generating default values, the generator did not " +
                 $"generate both a default and non-default value. The randomization approach " +
                 $"is unbalanced."
             );
         }
 
-        public class ObjectGenerator : IGenerator<Object> {
+        public void InvokeGenericMethod(
+            String methodName,
+            params Object[] parameters) {
 
-            public Object Next() {
-                return new Object();
+            if (methodName == null) {
+                throw new ArgumentNullException(nameof(methodName));
             }
 
+            if (parameters == null) {
+                throw new ArgumentNullException(nameof(parameters));
+            }
+
+            if (parameters.Length == 0) {
+                throw new ArgumentException(
+                    $"The first argument must be of type {typeof(IComparableGenerator<>).Name}.",
+                    nameof(parameters)
+                );
+            }
+
+            var interfaceType =
+                parameters[0]
+                    .GetType()
+                    .GetInterfaces()
+                    .SingleOrDefault(type => type.Name.StartsWith("IComparableGenerator"));
+
+            if (interfaceType == null) {
+                throw new ArgumentException(
+                    $"The first argument must be of type {typeof(IComparableGenerator<>).Name}.",
+                    nameof(parameters)
+                );
+            }
+
+            var fakeType = interfaceType.GetGenericArguments().Single();
+
+            var method = this.GetType().GetMethod(methodName);
+
+            if (method == null) {
+                throw new ArgumentException($"Unable to find method '{methodName}'");
+            }
+
+            method
+                .MakeGenericMethod(new Type[] { fakeType })
+                .Invoke(this, parameters);
         }
 
     }

--- a/test/Peddler.Tests/StringGeneratorTests.cs
+++ b/test/Peddler.Tests/StringGeneratorTests.cs
@@ -117,6 +117,7 @@ namespace Peddler {
 
                 Assert.InRange(value.Length, 0, 255);
                 Assert.DoesNotContain(value, character => !characters.Contains(character));
+                Assert.True(generator.EqualityComparer.Equals(value, value));
             }
         }
 
@@ -143,16 +144,22 @@ namespace Peddler {
                 Assert.NotEqual(value, other);
                 Assert.InRange(value.Length, 0, 255);
                 Assert.DoesNotContain(value, character => !characters.Contains(character));
+                Assert.False(generator.EqualityComparer.Equals(other, value));
             }
         }
 
         [Fact]
         public void NextDistinct_NullOther() {
+            const string other = null;
             var generator = new StringGenerator();
 
-            Assert.Throws<ArgumentNullException>(
-                () => generator.NextDistinct(null)
-            );
+            for (var attempt = 0; attempt < numberOfAttempts; attempt++) {
+                var value = generator.NextDistinct(other);
+
+                Assert.NotEqual(value, other);
+                Assert.InRange(value.Length, 0, 255);
+                Assert.False(generator.EqualityComparer.Equals(other, value));
+            }
         }
 
         [Theory]
@@ -168,6 +175,7 @@ namespace Peddler {
 
                 Assert.Equal(length, value.Length);
                 Assert.DoesNotContain(value, character => !characters.Contains(character));
+                Assert.True(generator.EqualityComparer.Equals(value, value));
             }
         }
 
@@ -189,6 +197,7 @@ namespace Peddler {
                 Assert.NotEqual(value, other);
                 Assert.Equal(length, value.Length);
                 Assert.DoesNotContain(value, character => !characters.Contains(character));
+                Assert.False(generator.EqualityComparer.Equals(other, value));
             }
         }
 
@@ -204,6 +213,7 @@ namespace Peddler {
 
                 Assert.Equal(length, value.Length);
                 Assert.DoesNotContain(value, character => !alphabet.Contains(character));
+                Assert.True(generator.EqualityComparer.Equals(value, value));
             }
         }
 
@@ -237,6 +247,7 @@ namespace Peddler {
                 Assert.NotEqual(value, other);
                 Assert.Equal(length, value.Length);
                 Assert.DoesNotContain(value, character => !characters.Contains(character));
+                Assert.False(generator.EqualityComparer.Equals(other, value));
             }
         }
 
@@ -267,6 +278,7 @@ namespace Peddler {
 
                 Assert.InRange(value.Length, minimum, maximum);
                 Assert.DoesNotContain(value, character => !characters.Contains(character));
+                Assert.True(generator.EqualityComparer.Equals(value, value));
             }
         }
 
@@ -291,6 +303,7 @@ namespace Peddler {
                 Assert.NotEqual(value, other);
                 Assert.InRange(value.Length, minimum, maximum);
                 Assert.DoesNotContain(value, character => !characters.Contains(character));
+                Assert.False(generator.EqualityComparer.Equals(other, value));
             }
         }
 
@@ -307,6 +320,7 @@ namespace Peddler {
 
                 Assert.InRange(value.Length, minimum, maximum);
                 Assert.DoesNotContain(value, character => !alphabet.Contains(character));
+                Assert.True(generator.EqualityComparer.Equals(value, value));
             }
         }
 
@@ -342,6 +356,7 @@ namespace Peddler {
                 Assert.NotEqual(value, other);
                 Assert.InRange(value.Length, minimum, maximum);
                 Assert.DoesNotContain(value, character => !characters.Contains(character));
+                Assert.False(generator.EqualityComparer.Equals(other, value));
             }
         }
 


### PR DESCRIPTION
Useful for periodically generating null or default(T) of structs. Updated tests and documentation to reflect the addition of these three new "mutating" or "wrapping" generators.