### PR TITLE
Add 'ListOfGenerator<T>' implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Peddler includes implementations for many of the basic data types of the .NET Fr
 | [Guid](src/Peddler/GuidGenerator.cs) | X | X |   |   |
 | [DateTime](src/Peddler/DateTimeGenerator.cs) | X | X | X | Enforces consistent use of [`DateTimeKind`](https://msdn.microsoft.com/en-us/library/shx7s921.aspx) |
 | [String](src/Peddler/StringGenerator.cs) | X | X |   | Uses [`StringComparison.Ordinal`](https://msdn.microsoft.com/en-us/library/system.stringcomparison.aspx) rules |
-| [Enum<T>](src/Peddler/EnumGenerator.cs) | X | X |   |   |
+| [Enum&lt;T&gt;](src/Peddler/EnumGenerator.cs) | X | X |   |   |
 | [Boolean](src/Peddler/BooleanGenerator.cs) | X | X |   |   |
 
 ## Wrapper Implementations
@@ -95,13 +95,13 @@ Peddler also includes implementations that wrap around base implementations or c
 
 | Type | `IGenerator<T>` | `IDistinctGenerator<T>` | `IComparableGenerator<T>` | Notes |
 | ---- |:---------------:|:-----------------------:|:-------------------------:| ----- |
-| [MaybeDefault<T>](src/Peddler/MaybeDefaultGenerator.cs) | X | | | Returns predefined "default value" periodically
-| [MaybeDefaultDistinct<T>](src/Peddler/MaybeDefaultDistinctGenerator.cs) | X | X | | Returns predefined "default value" periodically
-| [MaybeDefaultComparable<T>](src/Peddler/MaybeDefaultComparableGenerator.cs) | X | X | X | Returns predefined "default value" periodically
-| [Nullable<T>](src/Peddler/NullableGenerator.cs) | X | | | Converts `<T>` to `Nullable<T>`
-| [NullableDistinct<T>](src/Peddler/NullableDistinctGenerator.cs) | X | X | | Converts `<T>` to `Nullable<T>`
-| [NullableComparable<T>](src/Peddler/NullableComparableGenerator.cs) | X | X | X | Converts `<T>` to `Nullable<T>`
-| [Set<T>](src/Peddler/SetGenerator.cs) | X | X | | Returns values from injected `ISet<T>`
+| [MaybeDefault&lt;T&gt;](src/Peddler/MaybeDefaultGenerator.cs) | X | | | Returns predefined "default value" periodically
+| [MaybeDefaultDistinct&lt;T&gt;](src/Peddler/MaybeDefaultDistinctGenerator.cs) | X | X | | Returns predefined "default value" periodically
+| [MaybeDefaultComparable&lt;T&gt;](src/Peddler/MaybeDefaultComparableGenerator.cs) | X | X | X | Returns predefined "default value" periodically
+| [Nullable&lt;T&gt;](src/Peddler/NullableGenerator.cs) | X | | | Converts `<T>` to `Nullable<T>`
+| [NullableDistinct&lt;T&gt;](src/Peddler/NullableDistinctGenerator.cs) | X | X | | Converts `<T>` to `Nullable<T>`
+| [NullableComparable&lt;T&gt;](src/Peddler/NullableComparableGenerator.cs) | X | X | X | Converts `<T>` to `Nullable<T>`
+| [Set&lt;T&gt;](src/Peddler/SetGenerator.cs) | X | X | | Returns values from injected `ISet<T>`
 
 
 ## Constraints

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Peddler also includes implementations that wrap around base implementations or c
 | [NullableDistinct&lt;T&gt;](src/Peddler/NullableDistinctGenerator.cs) | X | X | | Converts `<T>` to `Nullable<T>`
 | [NullableComparable&lt;T&gt;](src/Peddler/NullableComparableGenerator.cs) | X | X | X | Converts `<T>` to `Nullable<T>`
 | [Set&lt;T&gt;](src/Peddler/SetGenerator.cs) | X | X | | Returns values from injected `ISet<T>`
-
+| [ListOf&lt;T&gt;](src/Peddler/ListOfGenerator.cs) | X | | | Returns immutable lists with values of type `T`
 
 ## Constraints
 

--- a/src/Peddler/ListOfGenerator.cs
+++ b/src/Peddler/ListOfGenerator.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace Peddler {
+
+    /// <summary>
+    ///   An <see cref="IGenerator{TList}" /> that will provide
+    ///   immutable lists of values of type <typeparamref name="T" />.
+    /// </summary>
+    public class ListOfGenerator<T> : IGenerator<IList<T>> {
+
+        private Random random { get; } = new Random();
+        private IGenerator<T> inner { get; }
+        private int minimumSize { get; }
+        private int maximumSize { get; }
+
+        /// <summary>
+        ///   Instantiates a <see cref="ListOfGenerator{T}" /> that will
+        ///   provide lists of values of type <typeparamref name="T" />
+        ///   that range in size between 1 and 10 values.
+        /// </summary>
+        /// <param name="inner">
+        ///   An <see cref="IGenerator{T}" /> implementation that will
+        ///   be used to generate values of type <typeparamref name="T" />
+        ///   that are ultimately put into an immutable list.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///   Thrown when <paramref name="inner" /> is null.
+        /// </exception>
+        public ListOfGenerator(IGenerator<T> inner) : this(inner, 1, 10) {}
+
+        /// <summary>
+        ///   Instantiates a <see cref="ListOfGenerator{T}" /> that will
+        ///   provide lists of values of type <typeparamref name="T" />
+        ///   that are of a size equal to <paramref name="numberOfValues" />.
+        /// </summary>
+        /// <param name="inner">
+        ///   An <see cref="IGenerator{T}" /> implementation that will
+        ///   be used to generate values of type <typeparamref name="T" />
+        ///   that are ultimately put into an immutable list.
+        /// </param>
+        /// <param name="numberOfValues">
+        ///   The size of the lists that will be generated.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///   Thrown when <paramref name="inner" /> is null.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   Thrown when <paramref name="numberOfValues" /> is
+        ///   less than zero or equal to Int32.MaxValue.
+        /// </exception>
+        public ListOfGenerator(IGenerator<T> inner, int numberOfValues) {
+            if (inner == null) {
+                throw new ArgumentNullException(nameof(inner));
+            }
+
+            if (numberOfValues < 0 || numberOfValues == Int32.MaxValue) {
+                throw new ArgumentOutOfRangeException(
+                    nameof(numberOfValues),
+                    $"'{nameof(numberOfValues)}' ({numberOfValues:N0}) must be " +
+                    $"greater than or equal to zero, and less than Int32.MaxValue."
+                );
+            }
+
+            this.inner = inner;
+            this.minimumSize = numberOfValues;
+            this.maximumSize = numberOfValues;
+        }
+
+        /// <summary>
+        ///   Instantiates a <see cref="ListOfGenerator{T}" /> that will
+        ///   provide lists of values of type <typeparamref name="T" />
+        ///   that are of a size that is greater than or equal to
+        ///   <paramref name="minimumSize" />, but less than or equal to
+        ///   <paramref name="maximumSize" />.
+        /// </summary>
+        /// <param name="inner">
+        ///   An <see cref="IGenerator{T}" /> implementation that will
+        ///   be used to generate values of type <typeparamref name="T" />
+        ///   that are ultimately put into an immutable list.
+        /// </param>
+        /// <param name="minimumSize">
+        ///   The inclusive, minimum boundary for the size of the lists
+        ///   that will be generated.
+        /// </param>
+        /// <param name="maximumSize">
+        ///   The inclusive, maximum boundary for the size of the lists
+        ///   that will be generated.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///   Thrown when <paramref name="inner" /> is null.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   Thrown when <paramref name="minimumSize" />
+        ///   or <paramref name="maximumSize" /> is less
+        ///   than zero or equal to Int32.MaxValue.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   Thrown when <paramref name="minimumSize" />
+        ///   is greater than <paramref name="maximumSize" />.
+        /// </exception>
+        public ListOfGenerator(IGenerator<T> inner, int minimumSize, int maximumSize) {
+            if (inner == null) {
+                throw new ArgumentNullException(nameof(inner));
+            }
+
+            if (minimumSize < 0 || minimumSize == Int32.MaxValue) {
+                throw new ArgumentOutOfRangeException(
+                    nameof(minimumSize),
+                    $"'{nameof(minimumSize)}' ({minimumSize:N0}) must be greater " +
+                    $"than or equal to zero, and less than Int32.MaxValue."
+                );
+            }
+
+            if (maximumSize < 0 || maximumSize == Int32.MaxValue) {
+                throw new ArgumentOutOfRangeException(
+                    nameof(maximumSize),
+                    $"'{nameof(maximumSize)}' ({maximumSize:N0}) must be greater " +
+                    $"than or equal to zero, and less than Int32.MaxValue."
+                );
+            }
+
+            if (minimumSize > maximumSize) {
+                throw new ArgumentException(
+                    $"The '{nameof(minimumSize)}' argument ({minimumSize:N0}) must not be " +
+                    $"greater than the '{nameof(maximumSize)}' argument ({maximumSize:N0})."
+                );
+            }
+
+            this.inner = inner;
+            this.minimumSize = minimumSize;
+            this.maximumSize = maximumSize;
+        }
+
+        /// <inheritdoc />
+        public IList<T> Next() {
+            return
+                Enumerable
+                    .Range(0, this.random.Next(this.minimumSize, this.maximumSize + 1))
+                    .Select(_ => this.inner.Next())
+                    .ToImmutableList();
+        }
+
+    }
+
+}

--- a/src/Peddler/SetGenerator.cs
+++ b/src/Peddler/SetGenerator.cs
@@ -6,8 +6,8 @@ using System.Linq;
 namespace Peddler {
 
     /// <summary>
-    ///   An <see cref="IDistinctGenerator{T}" /> that provides values from an explicit
-    ///   for providing instances of type <typeparamref name="T" />.
+    ///   An <see cref="IDistinctGenerator{T}" /> that provides values from an
+    ///   injected set of instances of type <typeparamref name="T" />.
     /// </summary>
     /// <typeparam name="T">
     ///   The C#/.NET Type of value generated.

--- a/test/Peddler.Tests/CharacterSetsTests.cs
+++ b/test/Peddler.Tests/CharacterSetsTests.cs
@@ -31,8 +31,8 @@ namespace Peddler {
                     .Select(Convert.ToInt32);
 
             foreach (var character in filtered) {
-                Assert.True(character >= 0, $"Unexpected character '\\u{character:x4}'.");
-                Assert.True(character <= 31, $"Unexpected character '\\u{character:x4}'.");
+                Assert.True(character >= 0, $"Unexpected character '\\u{(int)character:x4}'.");
+                Assert.True(character <= 31, $"Unexpected character '\\u{(int)character:x4}'.");
             }
         }
 
@@ -47,8 +47,8 @@ namespace Peddler {
             Assert.Contains(126, characters);
 
             foreach (var character in characters) {
-                Assert.True(character >= 32, $"Unexpected character '\\u{character:x4}'.");
-                Assert.True(character <= 126, $"Unexpected character '\\u{character:x4}'.");
+                Assert.True(character >= 32, $"Unexpected character '\\u{(int)character:x4}'.");
+                Assert.True(character <= 126, $"Unexpected character '\\u{(int)character:x4}'.");
             }
         }
 
@@ -63,8 +63,8 @@ namespace Peddler {
             Assert.Contains(255, characters);
 
             foreach (var character in characters) {
-                Assert.True(character >= 128, $"Unexpected character '\\u{character:x4}'.");
-                Assert.True(character <= 255, $"Unexpected character '\\u{character:x4}'.");
+                Assert.True(character >= 128, $"Unexpected character '\\u{(int)character:x4}'.");
+                Assert.True(character <= 255, $"Unexpected character '\\u{(int)character:x4}'.");
             }
         }
 
@@ -75,7 +75,7 @@ namespace Peddler {
             foreach (var character in CharacterSets.AsciiAlphabetical) {
                 Assert.True(
                     Char.IsLetter(character),
-                    $"Unexpected character '\\u{character:x4}'."
+                    $"Unexpected character '\\u{(int)character:x4}'."
                 );
 
                 if (Char.IsLower(character)) {

--- a/test/Peddler.Tests/ListOfGeneratorTests.cs
+++ b/test/Peddler.Tests/ListOfGeneratorTests.cs
@@ -1,0 +1,277 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Peddler {
+
+    public class ListOfGeneratorTests {
+
+        private const int numberOfAttempts = 100;
+
+        [Fact]
+        public void Constructor_DefaultSizes_NullInnerGenerator() {
+
+            // Arrange
+
+            IGenerator<Object> inner = null;
+
+            // Act
+
+            var exception = Record.Exception(
+                () => new ListOfGenerator<Object>(inner)
+            );
+
+            // Assert
+
+            Assert.IsType<ArgumentNullException>(exception);
+        }
+
+        [Fact]
+        public void Constructor_ConstantSize_NullInnerGenerator() {
+
+            // Arrange
+
+            IGenerator<Object> inner = null;
+
+            // Act
+
+            var exception = Record.Exception(
+                () => new ListOfGenerator<Object>(inner, 10)
+            );
+
+            // Assert
+
+            Assert.IsType<ArgumentNullException>(exception);
+        }
+
+        [Fact]
+        public void Constructor_ConfiguredSizes_NullInnerGenerator() {
+
+            // Arrange
+
+            IGenerator<Object> inner = null;
+
+            // Act
+
+            var exception = Record.Exception(
+                () => new ListOfGenerator<Object>(inner, 5, 15)
+            );
+
+            // Assert
+
+            Assert.IsType<ArgumentNullException>(exception);
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(Int32.MinValue)]
+        public void Constructor_NumberOfValues_LessThanZero(int numberOfValues) {
+
+            // Arrange
+
+            var inner = new StringGenerator();
+
+            // Act
+
+            var exception = Record.Exception(
+                () => new ListOfGenerator<String>(inner, numberOfValues)
+            );
+
+            // Assert
+
+            Assert.IsType<ArgumentOutOfRangeException>(exception);
+            Assert.Equal(
+                $"'numberOfValues' ({numberOfValues:N0}) must be greater " +
+                $"than or equal to zero, and less than Int32.MaxValue." +
+                Environment.NewLine + "Parameter name: numberOfValues",
+                exception.Message
+            );
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(Int32.MinValue)]
+        [InlineData(Int32.MaxValue)]
+        public void Constructor_ConfiguredSizes_InvalidMinimumSize(int minimumSize) {
+
+            // Arrange
+
+            var inner = new StringGenerator();
+
+            // Act
+
+            var exception = Record.Exception(
+                () => new ListOfGenerator<String>(inner, minimumSize, 100)
+            );
+
+            // Assert
+
+            Assert.IsType<ArgumentOutOfRangeException>(exception);
+            Assert.Equal(
+                $"'minimumSize' ({minimumSize:N0}) must be greater " +
+                $"than or equal to zero, and less than Int32.MaxValue." +
+                Environment.NewLine + "Parameter name: minimumSize",
+                exception.Message
+            );
+        }
+
+        [Fact]
+        public void Constructor_ConfiguredSizes_BothAreInt32MaxValue() {
+
+            // Arrange
+
+            var inner = new StringGenerator();
+
+            // Act
+
+            var exception = Record.Exception(
+                () => new ListOfGenerator<String>(inner, Int32.MaxValue, Int32.MaxValue)
+            );
+
+            // Assert
+
+            Assert.IsType<ArgumentOutOfRangeException>(exception);
+            Assert.Equal(
+                $"'minimumSize' ({Int32.MaxValue:N0}) must be greater " +
+                $"than or equal to zero, and less than Int32.MaxValue." +
+                Environment.NewLine + "Parameter name: minimumSize",
+                exception.Message
+            );
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(Int32.MinValue)]
+        [InlineData(Int32.MaxValue)]
+        public void Constructor_ConfiguredSizes_InvalidMaximumSize(int maximumSize) {
+
+            // Arrange
+
+            var inner = new StringGenerator();
+
+            // Act
+
+            var exception = Record.Exception(
+                () => new ListOfGenerator<String>(inner, 1, maximumSize)
+            );
+
+            // Assert
+
+            Assert.IsType<ArgumentOutOfRangeException>(exception);
+            Assert.Equal(
+                $"'maximumSize' ({maximumSize:N0}) must be greater " +
+                $"than or equal to zero, and less than Int32.MaxValue." +
+                Environment.NewLine + "Parameter name: maximumSize",
+                exception.Message
+            );
+        }
+
+        [Theory]
+        [InlineData(1, 0)]
+        [InlineData(10, 5)]
+        [InlineData(5, 2)]
+        public void Constructor_ConfiguredSizes_MinimumGreaterThanMaximum(
+            int minimumSize,
+            int maximumSize) {
+
+            // Arrange
+
+            var inner = new StringGenerator();
+
+            // Act
+
+            var exception = Record.Exception(
+                () => new ListOfGenerator<String>(inner, minimumSize, maximumSize)
+            );
+
+            // Assert
+
+            Assert.IsType<ArgumentException>(exception);
+            Assert.Equal(
+                $"The 'minimumSize' argument ({minimumSize:N0}) must not be " +
+                $"greater than the 'maximumSize' argument ({maximumSize:N0}).",
+                exception.Message
+            );
+        }
+
+        [Fact]
+        public void Next_DefaultsSizes() {
+            var generator =
+                new ListOfGenerator<String>(new StringGenerator());
+
+            for (var attempt = 0; attempt < numberOfAttempts; attempt++) {
+                var value = generator.Next();
+
+                Assert.NotNull(value);
+                AssertCountBetween(value, 1, 10);
+                AssertImmutable(value);
+            }
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(10)]
+        public void Next_ConstantSize(int numberOfValues) {
+            var generator =
+                new ListOfGenerator<String>(new StringGenerator(), numberOfValues);
+
+            for (var attempt = 0; attempt < numberOfAttempts; attempt++) {
+                var value = generator.Next();
+
+                Assert.NotNull(value);
+                AssertCountBetween(value, numberOfValues, numberOfValues);
+                AssertImmutable(value);
+            }
+        }
+
+        [Theory]
+        [InlineData(0, 0)]
+        [InlineData(0, 1)]
+        [InlineData(2, 4)]
+        [InlineData(1, 100)]
+        public void Next_ConfiguredSizes(int minimumSize, int maximumSize) {
+            var generator =
+                new ListOfGenerator<String>(new StringGenerator(), minimumSize, maximumSize);
+
+            for (var attempt = 0; attempt < numberOfAttempts; attempt++) {
+                var value = generator.Next();
+
+                Assert.NotNull(value);
+                AssertCountBetween(value, minimumSize, maximumSize);
+                AssertImmutable(value);
+            }
+        }
+
+        private void AssertCountBetween<T>(IList<T> list, int low, int high) {
+            if (list == null) {
+                throw new ArgumentNullException(nameof(list));
+            }
+
+            Assert.True(
+                list.Count >= low,
+                $"Expected list to have a count that is greater than " +
+                $"or equal to {low:N0}, but it was {list.Count:N0}."
+            );
+
+            Assert.True(
+                list.Count <= high,
+                $"Expected list to have a count that is less than " +
+                $"or equal to {high:N0}, but it was {list.Count:N0}."
+            );
+        }
+
+        private void AssertImmutable(IList<String> list) {
+            if (list == null) {
+                throw new ArgumentNullException(nameof(list));
+            }
+
+            Assert.Throws<NotSupportedException>(
+                () => list.Add("Foo")
+            );
+        }
+
+    }
+
+}


### PR DESCRIPTION
Fixes #24 

Provides a standardized way to generate lists of values that can be used within data objects that contains properties which are themselves lists.