### PR TITLE
Make all IGenerator<T> implementations thread-safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ PM> Install-Package Peddler
 
 # Basic Usage
 
-Peddler provides two things: Interfaces for how to design and compose your own data generation, as well as a collection of out-of-the-box generator implementations over the basic .NET types, such as DateTime, String, Guid, and Int32.
+Peddler provides two things: Interfaces for how to design and compose your own data generation, as well as a collection of out-of-the-box generator implementations over the basic .NET types, such as DateTime, String, Guid, and Int32. All implementations are thread-safe.
 
 ## Interfaces
 There are three main interfaces. The out-of-the-box generators implement at least one (but generally all three) of them, depending on their data type.

--- a/src/Peddler/BooleanGenerator.cs
+++ b/src/Peddler/BooleanGenerator.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 
 namespace Peddler {
 
@@ -8,7 +9,8 @@ namespace Peddler {
     /// </summary>
     public class BooleanGenerator : IDistinctGenerator<Boolean> {
 
-        private Random random { get; }
+        private static ThreadLocal<Random> random { get; } =
+            new ThreadLocal<Random>(() => new Random());
 
         /// <inheritdoc />
         public IEqualityComparer<Boolean> EqualityComparer { get; }
@@ -19,13 +21,12 @@ namespace Peddler {
         ///   of <c>true</c> and <c>false</c>.
         /// </summary>
         public BooleanGenerator() {
-            this.random = new Random();
             this.EqualityComparer = EqualityComparer<Boolean>.Default;
         }
 
         /// <inheritdoc />
         public Boolean Next() {
-            return this.random.NextBoolean();
+            return random.Value.NextBoolean();
         }
 
         /// <inheritdoc />

--- a/src/Peddler/ByteGenerator.cs
+++ b/src/Peddler/ByteGenerator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 
 namespace Peddler {
 
@@ -12,7 +13,8 @@ namespace Peddler {
     /// </remarks>
     public class ByteGenerator : IntegralGenerator<Byte> {
 
-        private Random random { get; } = new Random();
+        private static ThreadLocal<Random> random { get; } =
+            new ThreadLocal<Random>(() => new Random());
 
         /// <summary>
         ///   Instantiates an <see cref="ByteGenerator" /> that can create
@@ -53,7 +55,7 @@ namespace Peddler {
 
         /// <inheritdoc />
         protected override sealed Byte Next(Byte low, Byte high) {
-            return this.random.NextByte(low, high);
+            return random.Value.NextByte(low, high);
         }
 
         /// <inheritdoc />

--- a/src/Peddler/EnumGenerator.cs
+++ b/src/Peddler/EnumGenerator.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
 
 namespace Peddler {
 
@@ -11,10 +12,12 @@ namespace Peddler {
     /// </summary>
     public class EnumGenerator<TEnum> : IDistinctGenerator<TEnum> where TEnum : struct {
 
+        private static ThreadLocal<Random> random { get; }
         private static Lazy<ISet<TEnum>> defaultValues { get; }
         private static IEqualityComparer<TEnum> defaultEqualityComparer { get; }
 
         static EnumGenerator() {
+            random = new ThreadLocal<Random>(() => new Random());
             defaultValues = new Lazy<ISet<TEnum>>(GetEnumValues);
             defaultEqualityComparer = EqualityComparer<TEnum>.Default;
         }
@@ -47,7 +50,6 @@ namespace Peddler {
         /// <inheritdoc />
         public IEqualityComparer<TEnum> EqualityComparer { get; } = defaultEqualityComparer;
 
-        private Random random { get; } = new Random();
         private TEnum[] valuesLookup { get; }
         private IDictionary<TEnum, int> valuesReverseLookup { get; }
 
@@ -119,7 +121,7 @@ namespace Peddler {
 
         /// <inheritdoc />
         public virtual TEnum Next() {
-            return this.valuesLookup[this.random.Next(this.valuesLookup.Length)];
+            return this.valuesLookup[random.Value.Next(this.valuesLookup.Length)];
         }
 
         /// <inheritdoc />
@@ -140,7 +142,7 @@ namespace Peddler {
                 );
             }
 
-            var nextIndex = this.random.Next(this.valuesLookup.Length - 1);
+            var nextIndex = random.Value.Next(this.valuesLookup.Length - 1);
 
             if (nextIndex >= index) {
                 nextIndex++;

--- a/src/Peddler/Int16Generator.cs
+++ b/src/Peddler/Int16Generator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 
 namespace Peddler {
 
@@ -12,7 +13,8 @@ namespace Peddler {
     /// </remarks>
     public class Int16Generator : IntegralGenerator<Int16> {
 
-        private Random random { get; } = new Random();
+        private static ThreadLocal<Random> random { get; } =
+            new ThreadLocal<Random>(() => new Random());
 
         /// <summary>
         ///   Instantiates an <see cref="Int16Generator" /> that can create
@@ -53,7 +55,7 @@ namespace Peddler {
 
         /// <inheritdoc />
         protected override sealed Int16 Next(Int16 low, Int16 high) {
-            return this.random.NextInt16(low, high);
+            return random.Value.NextInt16(low, high);
         }
 
         /// <inheritdoc />

--- a/src/Peddler/Int32Generator.cs
+++ b/src/Peddler/Int32Generator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 
 namespace Peddler {
 
@@ -12,7 +13,8 @@ namespace Peddler {
     /// </remarks>
     public class Int32Generator : IntegralGenerator<Int32> {
 
-        private Random random { get; } = new Random();
+        private static ThreadLocal<Random> random { get; } =
+            new ThreadLocal<Random>(() => new Random());
 
         /// <summary>
         ///   Instantiates an <see cref="Int32Generator" /> that can create
@@ -53,7 +55,7 @@ namespace Peddler {
 
         /// <inheritdoc />
         protected override sealed Int32 Next(Int32 low, Int32 high) {
-            return this.random.Next(low, high);
+            return random.Value.Next(low, high);
         }
 
         /// <inheritdoc />

--- a/src/Peddler/Int64Generator.cs
+++ b/src/Peddler/Int64Generator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 
 namespace Peddler {
 
@@ -12,7 +13,8 @@ namespace Peddler {
     /// </remarks>
     public class Int64Generator : IntegralGenerator<Int64> {
 
-        private Random random { get; } = new Random();
+        private static ThreadLocal<Random> random { get; } =
+            new ThreadLocal<Random>(() => new Random());
 
         /// <summary>
         ///   Instantiates an <see cref="Int64Generator" /> that can create
@@ -53,7 +55,7 @@ namespace Peddler {
 
         /// <inheritdoc />
         protected override sealed Int64 Next(Int64 low, Int64 high) {
-            return this.random.NextInt64(low, high);
+            return random.Value.NextInt64(low, high);
         }
 
         /// <inheritdoc />

--- a/src/Peddler/ListOfGenerator.cs
+++ b/src/Peddler/ListOfGenerator.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Threading;
 
 namespace Peddler {
 
@@ -11,7 +12,9 @@ namespace Peddler {
     /// </summary>
     public class ListOfGenerator<T> : IGenerator<IList<T>> {
 
-        private Random random { get; } = new Random();
+        private static ThreadLocal<Random> random { get; } =
+            new ThreadLocal<Random>(() => new Random());
+
         private IGenerator<T> inner { get; }
         private int minimumSize { get; }
         private int maximumSize { get; }
@@ -138,7 +141,7 @@ namespace Peddler {
         public IList<T> Next() {
             return
                 Enumerable
-                    .Range(0, this.random.Next(this.minimumSize, this.maximumSize + 1))
+                    .Range(0, random.Value.Next(this.minimumSize, this.maximumSize + 1))
                     .Select(_ => this.inner.Next())
                     .ToImmutableList();
         }

--- a/src/Peddler/MaybeDefaultGenerator.cs
+++ b/src/Peddler/MaybeDefaultGenerator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 
 namespace Peddler {
 
@@ -13,13 +14,15 @@ namespace Peddler {
     /// </remarks>
     public class MaybeDefaultGenerator<T> : IGenerator<T> {
 
+        private static ThreadLocal<Random> random { get; } =
+            new ThreadLocal<Random>(() => new Random());
+
         /// <summary>
         ///   The value that is considered "the default value" that will
         ///   be occasionally be returned by this generator.
         /// </summary>
         public T DefaultValue { get; }
 
-        private Random random { get; } = new Random();
         private IGenerator<T> inner { get; }
         private decimal percentage { get; }
 
@@ -143,7 +146,7 @@ namespace Peddler {
         ///   should be returned instead of a value from the inner <see cref="IGenerator{T}" />.
         /// </summary>
         protected bool MaybeDefault() {
-            return (percentage - ((decimal)this.random.NextDouble())) >= 0m;
+            return (percentage - ((decimal)random.Value.NextDouble())) >= 0m;
         }
 
         /// <inheritdoc />

--- a/src/Peddler/SByteGenerator.cs
+++ b/src/Peddler/SByteGenerator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 
 namespace Peddler {
 
@@ -12,7 +13,8 @@ namespace Peddler {
     /// </remarks>
     public class SByteGenerator : IntegralGenerator<SByte> {
 
-        private Random random { get; } = new Random();
+        private static ThreadLocal<Random> random { get; } =
+            new ThreadLocal<Random>(() => new Random());
 
         /// <summary>
         ///   Instantiates an <see cref="SByteGenerator" /> that can create
@@ -53,7 +55,7 @@ namespace Peddler {
 
         /// <inheritdoc />
         protected override sealed SByte Next(SByte low, SByte high) {
-            return this.random.NextSByte(low, high);
+            return random.Value.NextSByte(low, high);
         }
 
         /// <inheritdoc />

--- a/src/Peddler/SetGenerator.cs
+++ b/src/Peddler/SetGenerator.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Threading;
 
 namespace Peddler {
 
@@ -14,10 +15,12 @@ namespace Peddler {
     /// </typeparam>
     public class SetGenerator<T> : IDistinctGenerator<T> {
 
+        private static ThreadLocal<Random> random { get; } =
+            new ThreadLocal<Random>(() => new Random());
+
         /// <inheritdoc />
         public virtual IEqualityComparer<T> EqualityComparer { get; }
 
-        private Random random { get; } = new Random();
         private ImmutableArray<T> valuesLookup { get; }
 
         /// <summary>
@@ -95,7 +98,7 @@ namespace Peddler {
 
         /// <inheritdoc />
         public T Next() {
-            return this.valuesLookup[this.random.Next(0, this.valuesLookup.Length)];
+            return this.valuesLookup[random.Value.Next(0, this.valuesLookup.Length)];
         }
 
         /// <inheritdoc />
@@ -116,7 +119,7 @@ namespace Peddler {
                 );
             }
 
-            var nextIndex = this.random.Next(0, this.valuesLookup.Length - 1);
+            var nextIndex = random.Value.Next(0, this.valuesLookup.Length - 1);
 
             if (currentIndex == nextIndex) {
                 nextIndex++;

--- a/src/Peddler/StringGenerator.cs
+++ b/src/Peddler/StringGenerator.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
+using System.Threading;
 
 namespace Peddler {
 
@@ -11,15 +12,16 @@ namespace Peddler {
     /// </summary>
     public class StringGenerator : IDistinctGenerator<String> {
 
+        private static ThreadLocal<Random> random { get; }
         private static ISet<Char> defaultCharacters { get; }
         private static StringComparer defaultComparer { get; }
 
         static StringGenerator() {
+            random = new ThreadLocal<Random>(() => new Random());
             defaultCharacters = CharacterSets.AsciiPrintable;
             defaultComparer = StringComparer.Ordinal;
         }
 
-        private Random random { get; } = new Random();
         private char[] charactersLookup { get; }
 
         /// <summary>
@@ -213,14 +215,14 @@ namespace Peddler {
         }
 
         private int NextInt32Inclusive(int low, int high) {
-            return (Int32)this.random.NextInt64(low, (Int64)(high + 1));
+            return (Int32)random.Value.NextInt64(low, (Int64)(high + 1));
         }
 
         private String NextOfLength(int length) {
             var buffer = new StringBuilder(length);
 
             for (var character = 0; character < length; character++) {
-                var index = this.random.Next(this.charactersLookup.Length);
+                var index = random.Value.Next(this.charactersLookup.Length);
 
                 buffer.Append(this.charactersLookup[index]);
             }
@@ -353,7 +355,7 @@ namespace Peddler {
                     }
                 }
 
-                buffer.Append(lookup[this.random.Next(lookup.Length)]);
+                buffer.Append(lookup[random.Value.Next(lookup.Length)]);
                 isDistinct = isDistinct || buffer[index] != other[index];
             }
 

--- a/src/Peddler/UInt16Generator.cs
+++ b/src/Peddler/UInt16Generator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 
 namespace Peddler {
 
@@ -12,7 +13,8 @@ namespace Peddler {
     /// </remarks>
     public class UInt16Generator : IntegralGenerator<UInt16> {
 
-        private Random random { get; } = new Random();
+        private static ThreadLocal<Random> random { get; } =
+            new ThreadLocal<Random>(() => new Random());
 
         /// <summary>
         ///   Instantiates an <see cref="UInt16Generator" /> that can create
@@ -53,7 +55,7 @@ namespace Peddler {
 
         /// <inheritdoc />
         protected override sealed UInt16 Next(UInt16 low, UInt16 high) {
-            return this.random.NextUInt16(low, high);
+            return random.Value.NextUInt16(low, high);
         }
 
         /// <inheritdoc />

--- a/src/Peddler/UInt32Generator.cs
+++ b/src/Peddler/UInt32Generator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 
 namespace Peddler {
 
@@ -12,7 +13,8 @@ namespace Peddler {
     /// </remarks>
     public class UInt32Generator : IntegralGenerator<UInt32> {
 
-        private Random random { get; } = new Random();
+        private static ThreadLocal<Random> random { get; } =
+            new ThreadLocal<Random>(() => new Random());
 
         /// <summary>
         ///   Instantiates an <see cref="UInt32Generator" /> that can create
@@ -53,7 +55,7 @@ namespace Peddler {
 
         /// <inheritdoc />
         protected override sealed UInt32 Next(UInt32 low, UInt32 high) {
-            return this.random.NextUInt32(low, high);
+            return random.Value.NextUInt32(low, high);
         }
 
         /// <inheritdoc />

--- a/src/Peddler/UInt64Generator.cs
+++ b/src/Peddler/UInt64Generator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 
 namespace Peddler {
 
@@ -12,7 +13,8 @@ namespace Peddler {
     /// </remarks>
     public class UInt64Generator : IntegralGenerator<UInt64> {
 
-        private Random random { get; } = new Random();
+        private static ThreadLocal<Random> random { get; } =
+            new ThreadLocal<Random>(() => new Random());
 
         /// <summary>
         ///   Instantiates an <see cref="UInt64Generator" /> that can create
@@ -53,7 +55,7 @@ namespace Peddler {
 
         /// <inheritdoc />
         protected override sealed UInt64 Next(UInt64 low, UInt64 high) {
-            return this.random.NextUInt64(low, high);
+            return random.Value.NextUInt64(low, high);
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Fixes #33 

Add tests to verify that System.Random didn't get into a broken state for all generators that utilize `System.Random`