### PR TITLE
Fix SetGenerator's distribution of values when calling NextDistinct()

### DIFF
--- a/src/Peddler/SetGenerator.cs
+++ b/src/Peddler/SetGenerator.cs
@@ -121,7 +121,7 @@ namespace Peddler {
 
             var nextIndex = random.Value.Next(0, this.valuesLookup.Length - 1);
 
-            if (currentIndex == nextIndex) {
+            if (nextIndex >= currentIndex) {
                 nextIndex++;
             }
 


### PR DESCRIPTION
Closes #44 