### PR TITLE
Update CI to use Solutions & Portable DebugTypes

### DIFF
--- a/Peddler.sln
+++ b/Peddler.sln
@@ -1,0 +1,56 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{D1798C00-1EEB-4F99-8B8D-E348BBBF1574}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Peddler", "src\Peddler\Peddler.csproj", "{50749CF4-F559-4A64-B88E-15CE19D8F123}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{E96DAD0C-8FE1-4FCB-BB56-865CFAE5B60A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Peddler.Tests", "test\Peddler.Tests\Peddler.Tests.csproj", "{EACFF658-BAEA-4175-B73E-55BD41D0682B}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{50749CF4-F559-4A64-B88E-15CE19D8F123}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{50749CF4-F559-4A64-B88E-15CE19D8F123}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{50749CF4-F559-4A64-B88E-15CE19D8F123}.Debug|x64.ActiveCfg = Debug|x64
+		{50749CF4-F559-4A64-B88E-15CE19D8F123}.Debug|x64.Build.0 = Debug|x64
+		{50749CF4-F559-4A64-B88E-15CE19D8F123}.Debug|x86.ActiveCfg = Debug|x86
+		{50749CF4-F559-4A64-B88E-15CE19D8F123}.Debug|x86.Build.0 = Debug|x86
+		{50749CF4-F559-4A64-B88E-15CE19D8F123}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{50749CF4-F559-4A64-B88E-15CE19D8F123}.Release|Any CPU.Build.0 = Release|Any CPU
+		{50749CF4-F559-4A64-B88E-15CE19D8F123}.Release|x64.ActiveCfg = Release|x64
+		{50749CF4-F559-4A64-B88E-15CE19D8F123}.Release|x64.Build.0 = Release|x64
+		{50749CF4-F559-4A64-B88E-15CE19D8F123}.Release|x86.ActiveCfg = Release|x86
+		{50749CF4-F559-4A64-B88E-15CE19D8F123}.Release|x86.Build.0 = Release|x86
+		{EACFF658-BAEA-4175-B73E-55BD41D0682B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EACFF658-BAEA-4175-B73E-55BD41D0682B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EACFF658-BAEA-4175-B73E-55BD41D0682B}.Debug|x64.ActiveCfg = Debug|x64
+		{EACFF658-BAEA-4175-B73E-55BD41D0682B}.Debug|x64.Build.0 = Debug|x64
+		{EACFF658-BAEA-4175-B73E-55BD41D0682B}.Debug|x86.ActiveCfg = Debug|x86
+		{EACFF658-BAEA-4175-B73E-55BD41D0682B}.Debug|x86.Build.0 = Debug|x86
+		{EACFF658-BAEA-4175-B73E-55BD41D0682B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EACFF658-BAEA-4175-B73E-55BD41D0682B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EACFF658-BAEA-4175-B73E-55BD41D0682B}.Release|x64.ActiveCfg = Release|x64
+		{EACFF658-BAEA-4175-B73E-55BD41D0682B}.Release|x64.Build.0 = Release|x64
+		{EACFF658-BAEA-4175-B73E-55BD41D0682B}.Release|x86.ActiveCfg = Release|x86
+		{EACFF658-BAEA-4175-B73E-55BD41D0682B}.Release|x86.Build.0 = Release|x86
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{50749CF4-F559-4A64-B88E-15CE19D8F123} = {D1798C00-1EEB-4F99-8B8D-E348BBBF1574}
+		{EACFF658-BAEA-4175-B73E-55BD41D0682B} = {E96DAD0C-8FE1-4FCB-BB56-865CFAE5B60A}
+	EndGlobalSection
+EndGlobal

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,7 @@ nuget:
 build_script:
 - ps: .\build.ps1
 after_build:
+- ps: .\set-debug-type.ps1
 - ps: .\coverage.ps1
 test: off
 artifacts:

--- a/build.ps1
+++ b/build.ps1
@@ -52,11 +52,8 @@ if(Test-Path .\artifacts) { Remove-Item .\artifacts -Force -Recurse }
 
 EnsurePsbuildInstalled
 
-exec { & dotnet restore .\src\Peddler }
-exec { & dotnet restore .\test\Peddler.Tests }
-
-exec { & dotnet build .\src\Peddler }
-exec { & dotnet build .\test\Peddler.Tests }
+exec { & dotnet restore }
+exec { & dotnet build }
 
 $revision = @{ $true = $env:APPVEYOR_BUILD_NUMBER; $false = 1 }[$env:APPVEYOR_BUILD_NUMBER -ne $NULL];
 $revision = "{0:D4}" -f [convert]::ToInt32($revision, 10)
@@ -66,4 +63,4 @@ $revision = "{0:D4}" -f [convert]::ToInt32($revision, 10)
 #    So while we're building in 4.6.2, but we are not running tests in 4.6.2
 exec { & dotnet test .\test\Peddler.Tests\Peddler.Tests.csproj -c Release -f netcoreapp1.0 }
 
-exec { & dotnet pack .\src\Peddler -c Release -o ..\..\artifacts }
+exec { & dotnet pack -c Release -o ..\..\artifacts }

--- a/build.sh
+++ b/build.sh
@@ -9,9 +9,8 @@ if [ -d $artifactsFolder ]; then
   rm -R $artifactsFolder
 fi
 
-dotnet restore ./src/Peddler
-dotnet restore ./test/Peddler.Tests
+dotnet restore
 
 dotnet test ./test/Peddler.Tests/Peddler.Tests.csproj -c Release -f netcoreapp1.0
 
-dotnet pack ./src/Peddler -c Release -o ../../artifacts
+dotnet pack -c Release -o ../../artifacts

--- a/set-debug-type.ps1
+++ b/set-debug-type.ps1
@@ -1,0 +1,8 @@
+$projectName = "Peddler"
+
+copy "src\${projectName}\${projectName}.csproj" "src\${projectName}\${projectName}.csproj.bak"
+
+$project = New-Object XML
+$project.Load("${pwd}\src\${projectName}\${projectName}.csproj")
+$project.Project.PropertyGroup.DebugType = "full"
+$project.Save("${pwd}\src\${projectName}\${projectName}.csproj")

--- a/src/Peddler/Peddler.csproj
+++ b/src/Peddler/Peddler.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Collections.Immutable" Version="1.3.0" />
-    <PackageReference Include="Invio.Hashing" Version="1.3.2" />
+    <PackageReference Include="Invio.Hashing" Version="1.3.3" />
   </ItemGroup>
 
 </Project>

--- a/src/Peddler/Peddler.csproj
+++ b/src/Peddler/Peddler.csproj
@@ -5,7 +5,7 @@
     <VersionPrefix>0.12.2</VersionPrefix>
     <Authors>Brian Caruso &lt;brian@invioinc.com&gt;</Authors>
     <TargetFramework>netstandard1.5</TargetFramework>
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Peddler</AssemblyName>
     <PackageId>Peddler</PackageId>

--- a/test/Peddler.Tests/Peddler.Tests.csproj
+++ b/test/Peddler.Tests/Peddler.Tests.csproj
@@ -12,6 +12,7 @@
     <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
       1.1.1
     </RuntimeFrameworkVersion>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Closes #48

Improves `dotnet` CLI developer ergonomics
Improves symbol export via `<DebugType>` of `portable`