### PR TITLE
Upgrade dependencies, run tests on .NET Core v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: csharp
 sudo: required
-dotnet: 1.0.4
+dotnet: 2.0.3
 
 matrix:
   include:

--- a/build.ps1
+++ b/build.ps1
@@ -58,9 +58,5 @@ exec { & dotnet build }
 $revision = @{ $true = $env:APPVEYOR_BUILD_NUMBER; $false = 1 }[$env:APPVEYOR_BUILD_NUMBER -ne $NULL];
 $revision = "{0:D4}" -f [convert]::ToInt32($revision, 10)
 
-#  Note from Caruso (9/21/2016):
-#    Appveyor does not appear to be able to test .NET Framework 4.6.2 with xUnit.
-#    So while we're building in 4.6.2, but we are not running tests in 4.6.2
-exec { & dotnet test .\test\Peddler.Tests\Peddler.Tests.csproj -c Release -f netcoreapp1.0 }
-
+exec { & dotnet test .\test\Peddler.Tests\Peddler.Tests.csproj -c Release }
 exec { & dotnet pack -c Release -o ..\..\artifacts }

--- a/build.sh
+++ b/build.sh
@@ -11,6 +11,6 @@ fi
 
 dotnet restore
 
-dotnet test ./test/Peddler.Tests/Peddler.Tests.csproj -c Release -f netcoreapp1.0
+dotnet test ./test/Peddler.Tests/Peddler.Tests.csproj -c Release
 
 dotnet pack -c Release -o ../../artifacts

--- a/coverage.ps1
+++ b/coverage.ps1
@@ -1,6 +1,6 @@
 nuget install OpenCover -Version 4.6.519 -OutputDirectory tools
 nuget install coveralls.net -Version 0.7.0 -OutputDirectory tools
 
-.\tools\OpenCover.4.6.519\tools\OpenCover.Console.exe -target:"C:\Program Files\dotnet\dotnet.exe" -targetargs:" test ""test\Peddler.Tests\Peddler.Tests.csproj"" -f netcoreapp1.0" -register:user -filter:"+[Peddler*]* -[xunit*]*" -oldStyle -returntargetcode -output:opencover_results.xml
+.\tools\OpenCover.4.6.519\tools\OpenCover.Console.exe -target:"C:\Program Files\dotnet\dotnet.exe" -targetargs:" test ""test\Peddler.Tests\Peddler.Tests.csproj"" " -register:user -filter:"+[Peddler*]* -[xunit*]*" -oldStyle -returntargetcode -output:opencover_results.xml
 
 .\tools\coveralls.net.0.7.0\tools\csmacnz.Coveralls.exe --opencover -i .\opencover_results.xml

--- a/src/Peddler/Peddler.csproj
+++ b/src/Peddler/Peddler.csproj
@@ -18,8 +18,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" Version="1.3.0" />
-    <PackageReference Include="Invio.Hashing" Version="1.3.3" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
+    <PackageReference Include="Invio.Hashing" Version="1.3.4" />
   </ItemGroup>
 
 </Project>

--- a/test/Peddler.Tests/IntegralGeneratorTests.cs
+++ b/test/Peddler.Tests/IntegralGeneratorTests.cs
@@ -88,7 +88,7 @@ namespace Peddler {
                 yield return new object[] { Add(minValue, 1), minValue };
                 yield return new object[] { maxValue, minValue };
                 yield return new object[] { minValue, minValue };
-                yield return new object[] { ToIntegral(0), ToIntegral(0) };
+                yield return new object[] { ToIntegral(1), ToIntegral(1) };
                 yield return new object[] { maxValue, maxValue };
             }
         }
@@ -123,7 +123,7 @@ namespace Peddler {
         public static IEnumerable<object[]> Next_WithLowDefined_RangeIsLowToMaxIntegralValue_Data {
             get {
                 yield return new object[] { minValue };
-                yield return new object[] { ToIntegral(0) };
+                yield return new object[] { ToIntegral(1) };
                 yield return new object[] { Add(maxValue, -1) };
             }
         }
@@ -149,7 +149,7 @@ namespace Peddler {
             get {
                 yield return new object[] { minValue, maxValue };
                 yield return new object[] { minValue, ToIntegral(1) };
-                yield return new object[] { ToIntegral(0), maxValue };
+                yield return new object[] { ToIntegral(1), maxValue };
             }
         }
 

--- a/test/Peddler.Tests/MaybeDefaultComparableGeneratorTests.cs
+++ b/test/Peddler.Tests/MaybeDefaultComparableGeneratorTests.cs
@@ -79,7 +79,7 @@ namespace Peddler {
             );
         }
 
-        public void NextLessThan_InnerReturnsDefaultImpl<T>(DefaultGenerator<T> inner) {
+        protected void NextLessThan_InnerReturnsDefaultImpl<T>(DefaultGenerator<T> inner) {
             var generator = this.MaybeDefaultComparable<T>(inner, inner.DefaultValue);
 
             Assert.Throws<UnableToGenerateValueException>(
@@ -195,7 +195,7 @@ namespace Peddler {
             );
         }
 
-        public void NextLessThan_FiftyPercentOfDefaultImpl<T>(
+        protected void NextLessThan_FiftyPercentOfDefaultImpl<T>(
             IComparableGenerator<T> inner,
             T otherValue) {
 
@@ -215,7 +215,7 @@ namespace Peddler {
             );
         }
 
-        public void NextLessThanOrEqualTo_InnerReturnsDefaultImpl<T>(
+        protected void NextLessThanOrEqualTo_InnerReturnsDefaultImpl<T>(
             DefaultGenerator<T> inner) {
 
             var generator = this.MaybeDefaultComparable<T>(inner, inner.DefaultValue);
@@ -295,7 +295,7 @@ namespace Peddler {
             );
         }
 
-        public void NextLessThanOrEqualTo_InnerFailsButDefaultOk_ClassImpl(
+        protected void NextLessThanOrEqualTo_InnerFailsButDefaultOk_ClassImpl(
             MaybeDefaultComparableGenerator<FakeClass> generator) {
 
             for (var attempt = 0; attempt < numberOfAttempts; attempt++) {
@@ -361,7 +361,7 @@ namespace Peddler {
             );
         }
 
-        public void NextLessThanOrEqualTo_FiftyPercentOfDefaultImpl<T>(
+        protected void NextLessThanOrEqualTo_FiftyPercentOfDefaultImpl<T>(
             IComparableGenerator<T> inner,
             T otherValue) {
 
@@ -381,7 +381,7 @@ namespace Peddler {
             );
         }
 
-        public void NextGreaterThanOrEqualTo_InnerReturnsDefaultImpl<T>(
+        protected void NextGreaterThanOrEqualTo_InnerReturnsDefaultImpl<T>(
             DefaultGenerator<T> inner) {
 
             var generator = this.MaybeDefaultComparable<T>(inner, inner.DefaultValue);
@@ -416,7 +416,7 @@ namespace Peddler {
             );
         }
 
-        public void NextGreaterThanOrEqualTo_InnerFailsButDefaultOkImpl(
+        protected void NextGreaterThanOrEqualTo_InnerFailsButDefaultOkImpl(
             MaybeDefaultComparableGenerator<FakeStruct> generator) {
 
             for (var attempt = 0; attempt < numberOfAttempts; attempt++) {
@@ -469,7 +469,7 @@ namespace Peddler {
             );
         }
 
-        public void NextGreaterThanOrEqualTo_FiftyPercentOfDefaultImpl<T>(
+        protected void NextGreaterThanOrEqualTo_FiftyPercentOfDefaultImpl<T>(
             IComparableGenerator<T> inner,
             T otherValue) {
 
@@ -489,7 +489,7 @@ namespace Peddler {
             );
         }
 
-        public void NextGreaterThan_InnerReturnsDefaultImpl<T>(DefaultGenerator<T> inner) {
+        protected void NextGreaterThan_InnerReturnsDefaultImpl<T>(DefaultGenerator<T> inner) {
             var generator = this.MaybeDefaultComparable<T>(inner, inner.DefaultValue);
 
             Assert.Throws<UnableToGenerateValueException>(
@@ -560,7 +560,7 @@ namespace Peddler {
             );
         }
 
-        public void NextGreaterThan_FiftyPercentOfDefaultImpl<T>(
+        protected void NextGreaterThan_FiftyPercentOfDefaultImpl<T>(
             IComparableGenerator<T> inner,
             T otherValue) {
 

--- a/test/Peddler.Tests/MaybeDefaultDistinctGeneratorTests.cs
+++ b/test/Peddler.Tests/MaybeDefaultDistinctGeneratorTests.cs
@@ -107,7 +107,7 @@ namespace Peddler {
             );
         }
 
-        public void NextDistinct_InnerCanGenerateNonDefaultImpl<T>(
+        protected void NextDistinct_InnerCanGenerateNonDefaultImpl<T>(
             IComparableGenerator<T> inner,
             T defaultValue) {
 
@@ -157,7 +157,7 @@ namespace Peddler {
             );
         }
 
-        public void NextDistinct_InnerOnlyReturnsDefaultImpl<T>(
+        protected void NextDistinct_InnerOnlyReturnsDefaultImpl<T>(
             DefaultGenerator<T> inner) {
 
             var generator = this.MaybeDefaultDistinct<T>(inner, inner.DefaultValue);
@@ -206,34 +206,34 @@ namespace Peddler {
 
         [Theory]
         [MemberData(nameof(FakeGenerators))]
-        public void NextDistinct_FiftyPercentageOfDefault(Object inner, Object defaultValue) {
+        public void NextDistinct_GeneratesDefaultAndNonDefault(Object inner, Object defaultValue) {
             this.InvokeGenericMethod(
-                nameof(NextDistinct_FiftyPercentageOfDefaultImpl),
+                nameof(NextDistinct_WithFiftyPercentChangeOfDefault),
                 inner,
                 defaultValue
             );
         }
 
-        public void NextDistinct_FiftyPercentageOfDefaultImpl<T>(
+        protected void NextDistinct_WithFiftyPercentChangeOfDefault<T>(
             IComparableGenerator<T> inner,
             T defaultValue) {
 
             const decimal percentage = 0.5m;
 
-            NextDistinct_FiftyPercentageOfDefaultImpl(
+            NextDistinct_WithFiftyPercentChangeOfDefaultImpl<T>(
                 this.MaybeDefaultDistinct<T>(inner, percentage),
                 inner.EqualityComparer,
                 percentage
             );
 
-            NextDistinct_FiftyPercentageOfDefaultImpl(
+            NextDistinct_WithFiftyPercentChangeOfDefaultImpl<T>(
                 this.MaybeDefaultDistinct<T>(inner, defaultValue, percentage),
                 inner.EqualityComparer,
                 percentage
             );
         }
 
-        private void NextDistinct_FiftyPercentageOfDefaultImpl<T>(
+        private void NextDistinct_WithFiftyPercentChangeOfDefaultImpl<T>(
             MaybeDefaultDistinctGenerator<T> generator,
             IEqualityComparer<T> innerComparer,
             decimal percentage) {

--- a/test/Peddler.Tests/MaybeDefaultGeneratorTests.cs
+++ b/test/Peddler.Tests/MaybeDefaultGeneratorTests.cs
@@ -174,7 +174,7 @@ namespace Peddler {
             );
         }
 
-        public void Next_ZeroPercentageOfDefaultImpl<T>(
+        protected void Next_ZeroPercentageOfDefaultImpl<T>(
             IComparableGenerator<T> inner,
             T otherDefault) {
 
@@ -201,7 +201,7 @@ namespace Peddler {
             );
         }
 
-        public void Next_OneHundredPercentageOfDefaultImpl<T>(
+        protected void Next_OneHundredPercentageOfDefaultImpl<T>(
             IComparableGenerator<T> inner,
             T defaultValue) {
 
@@ -220,34 +220,34 @@ namespace Peddler {
 
         [Theory]
         [MemberData(nameof(NonDefaultReturningGenerators))]
-        public void Next_FiftyPercentageOfDefault(Object inner, Object defaultValue) {
+        public void Next_GeneratesDefaultAndNonDefault(Object inner, Object defaultValue) {
             this.InvokeGenericMethod(
-                nameof(Next_FiftyPercentageOfDefaultImpl),
+                nameof(Next_WithFiftyPercentChangeOfDefault),
                 inner,
                 defaultValue
             );
         }
 
-        public void Next_FiftyPercentageOfDefaultImpl<T>(
+        protected void Next_WithFiftyPercentChangeOfDefault<T>(
             IComparableGenerator<T> inner,
             T defaultValue) {
 
             const decimal percentage = 0.5m;
 
-            Next_FiftyPercentageOfDefaultImpl(
+            this.Next_WithFiftyPercentChangeOfDefaultImpl<T>(
                 this.MaybeDefault<T>(inner, percentage),
                 inner.EqualityComparer,
                 percentage
             );
 
-            Next_FiftyPercentageOfDefaultImpl(
+            this.Next_WithFiftyPercentChangeOfDefaultImpl<T>(
                 this.MaybeDefault<T>(inner, defaultValue, percentage),
                 inner.EqualityComparer,
                 percentage
             );
         }
 
-        private void Next_FiftyPercentageOfDefaultImpl<T>(
+        private void Next_WithFiftyPercentChangeOfDefaultImpl<T>(
             MaybeDefaultGenerator<T> generator,
             IEqualityComparer<T> innerComparer,
             decimal percentage) {
@@ -335,7 +335,7 @@ namespace Peddler {
             }
         }
 
-        public void InvokeGenericMethod(
+        protected void InvokeGenericMethod(
             String methodName,
             params Object[] parameters) {
 
@@ -369,7 +369,11 @@ namespace Peddler {
 
             var fakeType = interfaceType.GetGenericArguments().Single();
 
-            var method = this.GetType().GetMethod(methodName);
+            const BindingFlags flags =
+                BindingFlags.Public | BindingFlags.NonPublic |
+                BindingFlags.Static | BindingFlags.Instance;
+
+            var method = this.GetType().GetMethod(methodName, flags);
 
             if (method == null) {
                 throw new ArgumentException($"Unable to find method '{methodName}'");

--- a/test/Peddler.Tests/Peddler.Tests.csproj
+++ b/test/Peddler.Tests/Peddler.Tests.csproj
@@ -1,17 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.0;net462</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>Peddler.Tests</AssemblyName>
     <PackageId>Peddler.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
+    <AssetTargetFallback>
       $(PackageTargetFallback);dotnet5.4;portable-net451+win8
-    </PackageTargetFallback>
-    <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
-      1.1.1
-    </RuntimeFrameworkVersion>
+    </AssetTargetFallback>
+    <RuntimeFrameworkVersion>2.0.3</RuntimeFrameworkVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -20,14 +18,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-*" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="xunit" Version="2.3.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
As part of the updates to the latest version of the xUnit dependencies, I had to tweaks the tests to make the xUnit static analyzers stop complaining about duplicate tests cases in theories, and public methods that looked like tests missing `[Theory]` and `[Fact]` attributes.