### PR TITLE
Add numeric, alphanumeric, and URL unreserved character sets

### DIFF
--- a/src/Peddler/CharacterSets.cs
+++ b/src/Peddler/CharacterSets.cs
@@ -14,22 +14,53 @@ namespace Peddler {
         /// <summary>
         ///   An immutable <see cref="ISet{Char}" /> of ASCII control characters.
         /// </summary>
+        /// <remarks>
+        ///   Source: https://en.wikipedia.org/wiki/ASCII#Control_characters
+        /// </remarks>
         public static ISet<Char> AsciiControl { get; }
 
         /// <summary>
         ///   An immutable <see cref="ISet{Char}" /> of ASCII printable characters.
         /// </summary>
+        /// <remarks>
+        ///   Source: https://en.wikipedia.org/wiki/ASCII#Printable_characters
+        /// </remarks>
         public static ISet<Char> AsciiPrintable { get; }
 
         /// <summary>
         ///   An immutable <see cref="ISet{Char}" /> of ASCII printable characters.
         /// </summary>
+        /// <remarks>
+        ///   Source: https://en.wikipedia.org/wiki/Extended_ASCII
+        /// </remarks>
         public static ISet<Char> AsciiExtended { get; }
 
         /// <summary>
         ///   An immutable <see cref="ISet{Char}" /> of alphabetical ASCII characters.
         /// </summary>
         public static ISet<Char> AsciiAlphabetical { get; }
+
+        /// <summary>
+        ///   An immutable <see cref="ISet{Char}" /> of ASCII numeric characters.
+        /// </summary>
+        public static ISet<Char> AsciiNumeric { get; }
+
+        /// <summary>
+        ///   An immutable <see cref="ISet{Char}" /> of ASCII alphanumeric characters.
+        /// </summary>
+        public static ISet<Char> AsciiAlphanumeric { get; }
+
+        /// <summary>
+        ///   An immutable <see cref="ISet{Char}" /> of ASCII characters that are
+        ///   not reserved for some functional purpose.
+        /// </summary>
+        /// <remarks>
+        ///   This list is plucked out the of RFC 3986, which defines valid characters
+        ///   that can be used in a URL that are "unreserved" for any functional purpose,
+        ///   such as a question mark for query strings, or a number sign for anchors.
+        ///   Source: https://tools.ietf.org/html/rfc3986#section-2.3
+        /// </remarks>
+        public static ISet<Char> AsciiUrlUnreserved { get; }
 
         static CharacterSets() {
             AsciiControl =
@@ -56,6 +87,22 @@ namespace Peddler {
                     .Range('a', 26)
                     .Concat(Enumerable.Range('A', 26))
                     .Select(Convert.ToChar)
+                    .ToImmutableHashSet();
+
+            AsciiNumeric =
+                Enumerable
+                    .Range('0', 10)
+                    .Select(Convert.ToChar)
+                    .ToImmutableHashSet();
+
+            AsciiAlphanumeric =
+                AsciiAlphabetical
+                    .Concat(AsciiNumeric)
+                    .ToImmutableHashSet();
+
+            AsciiUrlUnreserved =
+                AsciiAlphanumeric
+                    .Concat(new Char[] { '-', '.', '_', '~' })
                     .ToImmutableHashSet();
         }
 

--- a/test/Peddler.Tests/CharacterSetsTests.cs
+++ b/test/Peddler.Tests/CharacterSetsTests.cs
@@ -1,117 +1,323 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Globalization;
 using Xunit;
 
 namespace Peddler {
 
-    public class CharacterSetsTests {
+    public sealed class CharacterSetsTests {
 
-        [Fact]
-        public void AsciiControl_IsControl() {
-            foreach (var character in CharacterSets.AsciiControl) {
-                Assert.Equal(
-                    UnicodeCategory.Control,
-                    CharUnicodeInfo.GetUnicodeCategory(character)
-                );
-            }
+        public static IEnumerable<object[]> AsciiControl { get; } =
+            CharacterSets
+                .AsciiControl
+                .Select(character => new object[] { character })
+                .ToImmutableList();
+
+        [Theory]
+        [MemberData(nameof(AsciiControl))]
+        public void AsciiControl_IsControlCharacter(Char character) {
+
+            // Arrange
+
+            const UnicodeCategory expectedCategory = UnicodeCategory.Control;
+
+            // Act
+
+            var actualCategory = CharUnicodeInfo.GetUnicodeCategory(character);
+
+            // Assert
+
+            Assert.Equal(expectedCategory, actualCategory);
+        }
+
+        [Theory]
+        [MemberData(nameof(AsciiControl))]
+        public void AsciiControl_ContainsDeleteAndZeroTo31(Char character) {
+
+            // Arrange
+
+            const Char delete = '\u007f';
+
+            // Act
+
+            var isDelete = (character == delete);
+            var isZeroToThirtyOne = (0 <= character && character <= 31);
+
+            // Assert
+
+            Assert.True(
+                isDelete ^ isZeroToThirtyOne,
+                $"Unexpected character '\\u{(int)character:x4}'."
+            );
         }
 
         [Fact]
-        public void AsciiControl_ContainsDeleteAndZeroTo31() {
-            const Char DEL = '\u007f';
+        public void AsciiPrintable_Contains95Characters() {
 
-            Assert.Contains(DEL, CharacterSets.AsciiControl);
+            // Arrange
 
-            var filtered =
-                CharacterSets
-                    .AsciiControl
-                    .Where(character => character != DEL)
-                    .Select(Convert.ToInt32);
+            const int expectedCount = 95;  // Characters 32 - 126, inclusively
 
-            foreach (var character in filtered) {
-                Assert.True(character >= 0, $"Unexpected character '\\u{(int)character:x4}'.");
-                Assert.True(character <= 31, $"Unexpected character '\\u{(int)character:x4}'.");
-            }
+            // Act
+
+            var actualCount = CharacterSets.AsciiPrintable.Count;
+
+            // Assert
+
+            Assert.Equal(expectedCount, actualCount);
+        }
+
+        public static IEnumerable<object[]> AsciiPrintable { get; } =
+            CharacterSets
+                .AsciiPrintable
+                .Select(character => new object[] { character })
+                .ToImmutableList();
+
+        [Theory]
+        [MemberData(nameof(AsciiPrintable))]
+        public void AsciiPrintable_Ranges32To126(Char character) {
+
+            // Act
+
+            var isThirtyTwoToOneHundredTwentySix = (32 <= character && character <= 126);
+
+            // Assert
+
+            Assert.True(
+                isThirtyTwoToOneHundredTwentySix,
+                $"Unexpected character '\\u{(int)character:x4}'."
+            );
         }
 
         [Fact]
-        public void AsciiPrintable_Ranges32To126() {
-            var characters =
-                CharacterSets
-                    .AsciiPrintable
-                    .Select(Convert.ToInt32);
+        public void AsciiExtended_Contains128Characters() {
 
-            Assert.Contains(32, characters);
-            Assert.Contains(126, characters);
+            // Act
 
-            foreach (var character in characters) {
-                Assert.True(character >= 32, $"Unexpected character '\\u{(int)character:x4}'.");
-                Assert.True(character <= 126, $"Unexpected character '\\u{(int)character:x4}'.");
-            }
+            const int expectedCount = 128;  // Characters 128 - 255, inclusively
+
+            // Act
+
+            var actualCount = CharacterSets.AsciiExtended.Count;
+
+            // Assert
+
+            Assert.Equal(expectedCount, actualCount);
+        }
+
+        public static IEnumerable<object[]> AsciiExtended { get; } =
+            CharacterSets
+                .AsciiExtended
+                .Select(character => new object[] { character })
+                .ToImmutableList();
+
+        [Theory]
+        [MemberData(nameof(AsciiExtended))]
+        public void AsciiExtended_Ranges128To257(Char character) {
+
+            // Act
+
+            var isInExtendedAsciiRange = (128 <= character && character <= 255);
+
+            // Assert
+
+            Assert.True(
+                isInExtendedAsciiRange,
+                $"Unexpected character '\\u{(int)character:x4}'."
+            );
         }
 
         [Fact]
-        public void AsciiExtended_Ranges128To257() {
-            var characters =
-                CharacterSets
-                    .AsciiExtended
-                    .Select(Convert.ToInt32);
+        public void AsciiAlphabetical_Contains52Characters() {
 
-            Assert.Contains(128, characters);
-            Assert.Contains(255, characters);
+            // Arrange
 
-            foreach (var character in characters) {
-                Assert.True(character >= 128, $"Unexpected character '\\u{(int)character:x4}'.");
-                Assert.True(character <= 255, $"Unexpected character '\\u{(int)character:x4}'.");
-            }
+            const int expectedCount = 26 * 2; // 26 Lowercase, 26 Uppercase
+
+            // Act
+
+            var actualCount = CharacterSets.AsciiAlphabetical.Count;
+
+            // Assert
+
+            Assert.Equal(expectedCount, actualCount);
+        }
+
+        public static IEnumerable<Object[]> AsciiAlphabetical { get; } =
+            CharacterSets
+                .AsciiAlphabetical
+                .Select(character => new object[] { character })
+                .ToImmutableList();
+
+        [Theory]
+        [MemberData(nameof(AsciiAlphabetical))]
+        public void AsciiAlphabetical_IsUpperOrLowerLetter(Char character) {
+
+            // Act
+
+            var isLetter = Char.IsLetter(character);
+            var isLower = Char.IsLower(character);
+            var isUpper = Char.IsUpper(character);
+
+            // Assert
+
+            Assert.True(
+                isLetter,
+                $"Unexpected non-letter character '\\u{(int)character:x4}'."
+            );
+
+            Assert.True(
+                isLower ^ isUpper,
+                $"Expected '{character}' to be EITHER lower or upper case - not both.\n" +
+                $"  Char.IsLower('{character}') = {isLower}\n" +
+                $"  Char.IsUpper('{character}') = {isUpper}"
+            );
         }
 
         [Fact]
-        public void AsciiAlphabetical_IsLetterInAlphabet() {
-             Assert.Equal(26 * 2, CharacterSets.AsciiAlphabetical.Count);
+        public void AsciiNumeric_Contains10Characters() {
 
-            foreach (var character in CharacterSets.AsciiAlphabetical) {
-                Assert.True(
-                    Char.IsLetter(character),
-                    $"Unexpected character '\\u{(int)character:x4}'."
-                );
+            // Arrange
 
-                if (Char.IsLower(character)) {
-                    Assert.True(
-                        'a' <= character && character <= 'z',
-                        $"Unexpected character '{character}'."
-                    );
-                } else {
-                    Assert.True(
-                        Char.IsUpper(character),
-                        $"Unexpected character '{character}'."
-                    );
+            const int expectedCount = 10; // 0 - 9, inclusively
 
-                    Assert.True(
-                        'A' <= character && character <= 'Z',
-                        $"Unexpected character '{character}'."
-                    );
-                }
-            }
+            // Act
+
+            var actualCount = CharacterSets.AsciiNumeric.Count;
+
+            // Assert
+
+            Assert.Equal(expectedCount, actualCount);
         }
 
-        public static IEnumerable<object[]> CharacterSets_IsImmutable_Data {
-            get {
-                yield return new [] { CharacterSets.AsciiControl };
-                yield return new [] { CharacterSets.AsciiPrintable };
-                yield return new [] { CharacterSets.AsciiExtended };
-                yield return new [] { CharacterSets.AsciiAlphabetical };
-            }
+        public static IEnumerable<Object[]> AsciiNumeric { get; } =
+            CharacterSets
+                .AsciiNumeric
+                .Select(character => new object[] { character })
+                .ToImmutableList();
+
+        [Theory]
+        [MemberData(nameof(AsciiNumeric))]
+        public void AsciiNumeric_ContainsOnlyDigits(Char character) {
+
+            // Act
+
+            var isDigit = Char.IsDigit(character);
+
+            // Assert
+
+            Assert.True(
+                isDigit,
+                $"Unexpected non-digit character '\\u{(int)character:x4}'."
+            );
         }
+
+
+        [Fact]
+        public void AsciiAlphanumeric_Contains62Characters() {
+
+            // Arrange
+
+            const int expectedCount = 62; // 0 - 9 (inclusively), 26 lowercase, 26 uppercase
+
+            // Act
+
+            var actualCount = CharacterSets.AsciiAlphanumeric.Count;
+
+            // Assert
+
+            Assert.Equal(expectedCount, actualCount);
+        }
+
+        public static IEnumerable<Object[]> AsciiAlphanumeric { get; } =
+            CharacterSets
+                .AsciiAlphanumeric
+                .Select(character => new object[] { character })
+                .ToImmutableList();
+
+        [Theory]
+        [MemberData(nameof(AsciiAlphanumeric))]
+        public void AsciiAlphanumeric_ContainsLettersOrDigits(Char character) {
+
+            // Act
+
+            var isDigit = Char.IsDigit(character);
+            var isLetter = Char.IsLetter(character);
+
+            // Assert
+
+            Assert.True(
+                isDigit || isLetter,
+                $"Unexpected non-digit, non-letter character '\\u{(int)character:x4}'."
+            );
+
+            Assert.True(
+                isDigit ^ isLetter,
+                $"Expected '{character}' to be EITHER digit or letter - not both.\n" +
+                $"  Char.IsLower('{character}') = {isDigit}\n" +
+                $"  Char.IsUpper('{character}') = {isLetter}"
+            );
+        }
+
+        [Fact]
+        public void AsciiUrlUnreserved_Contains66Characters() {
+
+            // Arrange
+
+            // The following characters are expected:
+            //   * 0 - 9, inclusively       (10 characters)
+            //   * lowercase letters        (26 characters)
+            //   * uppercase letters        (26 characters)
+            //   * '-', '.', '_', '~'       ( 4 characters)
+            const int expectedCount = 66;
+
+            // Act
+
+            var actualCount = CharacterSets.AsciiUrlUnreserved.Count;
+
+            // Assert
+
+            Assert.Equal(expectedCount, actualCount);
+        }
+
+        [Theory]
+        [MemberData(nameof(AsciiAlphanumeric))]
+        [InlineData('-')]
+        [InlineData('.')]
+        [InlineData('_')]
+        [InlineData('~')]
+        public void AsciiUrlUnreserved_ActuallyContainsCorrectCharacters(Char character) {
+            Assert.Contains(character, CharacterSets.AsciiUrlUnreserved);
+        }
+
+        public static IEnumerable<object[]> CharacterSets_IsImmutable_Data { get; } =
+            ImmutableList<ISet<Char>>
+                .Empty
+                .Add(CharacterSets.AsciiControl)
+                .Add(CharacterSets.AsciiPrintable)
+                .Add(CharacterSets.AsciiExtended)
+                .Add(CharacterSets.AsciiAlphabetical)
+                .Add(CharacterSets.AsciiNumeric)
+                .Add(CharacterSets.AsciiAlphanumeric)
+                .Add(CharacterSets.AsciiUrlUnreserved)
+                .Select(characters => new object[] { characters })
+                .ToImmutableList();
 
         [Theory]
         [MemberData(nameof(CharacterSets_IsImmutable_Data))]
         public void CharacterSets_IsImmutable(ISet<Char> characters) {
-            Assert.Throws<NotSupportedException>(
+
+            // Act
+
+            var exception = Record.Exception(
                 () => characters.Add('A')
             );
+
+            // Assert
+
+            Assert.IsType<NotSupportedException>(exception);
         }
 
 


### PR DESCRIPTION
Closes out #50. There is demand further downstream in closed source code for more character sets, and these three new ones are all generic enough to put into Peddler.