### PR TITLE
Add `DateTimeUnit` granularity to `DateTimeGenerator` (#58)

### DIFF
--- a/src/Peddler/DateTimeUnit.cs
+++ b/src/Peddler/DateTimeUnit.cs
@@ -1,0 +1,53 @@
+using System;
+
+namespace Peddler {
+
+    /// <summary>
+    ///   The various types of units that make up a <see cref="DateTime" />.
+    /// </summary>
+    /// <remarks>
+    ///   These can be used to control the level of granularity a
+    ///   <see cref="DateTimeGenerator" /> uses when generating and differentiating
+    ///   various <see cref="DateTime" /> values.
+    /// </remarks>
+    public enum DateTimeUnit {
+
+        /// <summary>
+        ///   Represents a single "tick", the smallest unit of time that is able to be
+        ///   represented in a <see cref="DateTime" /> value.
+        /// </summary>
+        Tick,
+
+        /// <summary>
+        ///   Represents a millisecond, or 10000 ticks.
+        ///   This is one of the units of measurement used for a <see cref="DateTime" />.
+        /// </summary>
+        Millisecond,
+
+        /// <summary>
+        ///   Represents a second, or 10000000 ticks.
+        ///   This is one of the units of measurement used for a <see cref="DateTime" />.
+        /// </summary>
+        Second,
+
+        /// <summary>
+        ///   Represents a minute, or 600000000 ticks.
+        ///   This is one of the units of measurement used for a <see cref="DateTime" />.
+        /// </summary>
+        Minute,
+
+        /// <summary>
+        ///   Represents a hour, or 36000000000 ticks.
+        ///   This is one of the units of measurement used for a <see cref="DateTime" />.
+        /// </summary>
+        Hour,
+
+        /// <summary>
+        ///   Represents a day, or 864000000000 ticks.
+        ///   This is one of the units of measurement used for a <see cref="DateTime" />.
+        /// </summary>
+        Day
+
+    }
+
+}

--- a/src/Peddler/DateTimeUtilities.cs
+++ b/src/Peddler/DateTimeUtilities.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+namespace Peddler {
+
+    internal static class DateTimeUtilities {
+
+        private static IDictionary<DateTimeUnit, long> ticksPerUnitCache { get; }
+
+        static DateTimeUtilities() {
+            ticksPerUnitCache =
+                ImmutableDictionary<DateTimeUnit, long>
+                    .Empty
+                    .Add(DateTimeUnit.Tick, 1L)
+                    .Add(DateTimeUnit.Millisecond, TimeSpan.TicksPerMillisecond)
+                    .Add(DateTimeUnit.Second, TimeSpan.TicksPerSecond)
+                    .Add(DateTimeUnit.Minute, TimeSpan.TicksPerMinute)
+                    .Add(DateTimeUnit.Hour, TimeSpan.TicksPerHour)
+                    .Add(DateTimeUnit.Day, TimeSpan.TicksPerDay);
+        }
+
+        public static long GetTicksPerUnit(DateTimeUnit unit) {
+            return ticksPerUnitCache[unit];
+        }
+
+    }
+
+}

--- a/src/Peddler/KindSensitiveDateTimeComparer.cs
+++ b/src/Peddler/KindSensitiveDateTimeComparer.cs
@@ -9,6 +9,29 @@ namespace Peddler {
     /// </summary>
     public class KindSensitiveDateTimeComparer : Comparer<DateTime> {
 
+        private long ticksPerUnit { get; }
+
+        /// <summary>
+        ///   Creates an implementation of <see cref="Comparer{DateTime}" /> implementation
+        ///   that only allows comparisons of <see cref="DateTime" /> instances if they have
+        ///   the same <see cref="DateTimeKind" />.
+        /// </summary>
+        /// <param name="granularity">
+        ///   How granular the comparisons are between two <see cref="DateTime" /> values
+        ///   with the same <see cref="DateTimeKind" />. For example, a 
+        ///   <paramref name="granularity" /> of <see cref="DateTimeUnit.Day" />
+        ///   will consider any two <see cref="DateTime" /> values on the same day to be
+        ///   equivalent. However, a <paramref name="granularity" /> of
+        ///   <see cref="DateTimeUnit.Second" /> will consider any two <see cref="DateTime" />
+        ///   values for the same second to be equivalent. The default
+        ///   <paramref name="granularity" /> is <see cref="DateTimeUnit.Tick" />, which
+        ///   requires the number of ticks in each <see cref="DateTime" /> value to be
+        ///   identical in order for them to be considered equal.
+        /// </param>
+        public KindSensitiveDateTimeComparer(DateTimeUnit granularity = DateTimeUnit.Tick) {
+            this.ticksPerUnit = DateTimeUtilities.GetTicksPerUnit(granularity);
+        }
+
         /// <summary>
         ///   Verifies that the left and right are of the same <see cref="DateTimeKind" />,
         ///   then compares their internal ticks to determine if one is less than, greater
@@ -41,7 +64,8 @@ namespace Peddler {
                 );
             }
 
-            return left.CompareTo(right);
+
+            return (left.Ticks / this.ticksPerUnit).CompareTo(right.Ticks / this.ticksPerUnit);
         }
 
     }

--- a/src/Peddler/Properties/AssemblyInfo.cs
+++ b/src/Peddler/Properties/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+using System.Reflection;
+using System.Resources;
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Peddler.Tests")]

--- a/test/Peddler.Tests/DateTimeGeneratorTests.cs
+++ b/test/Peddler.Tests/DateTimeGeneratorTests.cs
@@ -1,10 +1,14 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Invio.Xunit;
 using Xunit;
 
 namespace Peddler {
 
-    public class DateTimeGeneratorTests : IntegralGeneratorTests<DateTime> {
+    [UnitTest]
+    public sealed class DateTimeGeneratorTests : IntegralGeneratorTests<DateTime> {
 
         protected override IIntegralGenerator<DateTime> CreateGenerator() {
             return new DateTimeGenerator();
@@ -46,7 +50,7 @@ namespace Peddler {
             Assert.Equal(date.Kind, generator.Kind);
         }
 
-        public static IEnumerable<object[]> Constructor_WithRange_ConsistentKinds_Data {
+        public static IEnumerable<object[]> Constructor_WithRange_ConsistentKinds_MemberData {
             get {
                 var ticks = DateTime.Now.Ticks;
 
@@ -68,7 +72,7 @@ namespace Peddler {
         }
 
         [Theory]
-        [MemberData(nameof(Constructor_WithRange_ConsistentKinds_Data))]
+        [MemberData(nameof(Constructor_WithRange_ConsistentKinds_MemberData))]
         public void Constructor_WithRange_ConsistentKinds(DateTime low, DateTime high) {
             var generator = new DateTimeGenerator(low, high);
 
@@ -76,7 +80,7 @@ namespace Peddler {
             Assert.Equal(high.Kind, generator.Kind);
         }
 
-        public static IEnumerable<object[]> Constructor_WithRange_MismatchedKinds_Data {
+        public static IEnumerable<object[]> Constructor_WithRange_MismatchedKinds_MemberData {
             get {
                 var ticks = DateTime.Now.Ticks;
 
@@ -98,92 +102,384 @@ namespace Peddler {
         }
 
         [Theory]
-        [MemberData(nameof(Constructor_WithRange_MismatchedKinds_Data))]
+        [MemberData(nameof(Constructor_WithRange_MismatchedKinds_MemberData))]
         public void Constructor_WithRange_MismatchedKinds(DateTime low, DateTime high) {
-            Assert.Throws<ArgumentException>(
+
+            // Act
+
+            var exception = Record.Exception(
                 () => new DateTimeGenerator(low, high)
             );
+
+            // Assert
+
+            Assert.IsType<ArgumentException>(exception);
+        }
+
+        public static IEnumerable<object[]> UnitsMemberData { get; } =
+            Enumerable
+                .Empty<DateTimeUnit>()
+                .Append(DateTimeUnit.Tick)
+                .Append(DateTimeUnit.Millisecond)
+                .Append(DateTimeUnit.Second)
+                .Append(DateTimeUnit.Minute)
+                .Append(DateTimeUnit.Hour)
+                .Append(DateTimeUnit.Day)
+                .Select(unit => new object[] { unit })
+                .ToImmutableList();
+
+        [Theory]
+        [MemberData(nameof(UnitsMemberData))]
+        public void Constructor_WithGranularity_LowAndHighOnInternal(
+            DateTimeUnit granularity) {
+
+            // Act
+
+            var generator = new DateTimeGenerator(granularity);
+
+            // Assert
+
+            AssertOnIntervalForGranularity(generator.Low, granularity);
+            AssertOnIntervalForGranularity(generator.High, granularity);
+        }
+
+        [Theory]
+        [MemberData(nameof(UnitsMemberData))]
+        public void Next_AlwaysReturnsValuesOnGranularityUnitsInterval(
+            DateTimeUnit granularity) {
+
+            // Arrange
+
+            var generator = new DateTimeGenerator(granularity);
+
+            // Act
+
+            var generated = generator.Next();
+
+            // Assert
+
+            AssertOnIntervalForGranularity(generated, granularity);
         }
 
         [Fact]
-        public void NextDistinct_MismatchedKind() {
+        public void NextDistinct_MismatchedKindStillReturnsCorrectKind() {
+
+            // Arrange
+
             var date = DateTime.SpecifyKind(DateTime.Now, DateTimeKind.Local);
             var generator = new DateTimeGenerator();
 
-            Assert.NotEqual(date.Kind, generator.Kind);
+            // Act
 
-            Assert.NotEqual(date, generator.NextDistinct(date));
+            var generated = generator.NextDistinct(date);
+
+            // Assert
+
+            Assert.Equal(DateTimeKind.Local, date.Kind);
+            Assert.Equal(DateTimeKind.Utc, generator.Kind);
+            Assert.Equal(DateTimeKind.Utc, generated.Kind);
+        }
+
+        [Theory]
+        [MemberData(nameof(UnitsMemberData))]
+        public void NextDistinct_AlwaysReturnsValuesOnGranularityUnitsInterval(
+            DateTimeUnit granularity) {
+
+            // Arrange
+
+            var generator = new DateTimeGenerator(granularity);
+
+            // Act
+
+            var generated = generator.NextDistinct(DateTime.UtcNow);
+
+            // Assert
+
+            AssertOnIntervalForGranularity(generated, granularity);
         }
 
         [Fact]
         public void NextLessThan_MismatchedKind() {
+
+            // Arrange
+
             var date = DateTime.SpecifyKind(DateTime.Now, DateTimeKind.Local);
             var generator = new DateTimeGenerator();
 
-            Assert.NotEqual(date.Kind, generator.Kind);
-            Assert.Throws<ArgumentException>(
+            // Act
+
+            var exception = Record.Exception(
                 () => generator.NextLessThan(date)
             );
+
+            // Assert
+
+            Assert.NotEqual(date.Kind, generator.Kind);
+            Assert.IsType<ArgumentException>(exception);
+        }
+
+        [Theory]
+        [MemberData(nameof(UnitsMemberData))]
+        public void NextLessThan_AlwaysReturnsValuesOnGranularityUnitsInterval(
+            DateTimeUnit granularity) {
+
+            // Arrange
+
+            var generator = new DateTimeGenerator(granularity);
+
+            // Act
+
+            var generated = generator.NextLessThan(DateTime.UtcNow);
+
+            // Assert
+
+            AssertOnIntervalForGranularity(generated, granularity);
         }
 
         [Fact]
         public void NextLessThanOrEqualTo_MismatchedKind() {
-            var date = DateTime.SpecifyKind(DateTime.Now, DateTimeKind.Local);
-            var generator = new DateTimeGenerator();
 
-            Assert.NotEqual(date.Kind, generator.Kind);
-            Assert.Throws<ArgumentException>(
+            // Arrange
+
+            var generator = new DateTimeGenerator();
+            var date = DateTime.SpecifyKind(DateTime.Now, DateTimeKind.Local);
+
+            // Act
+
+            var exception = Record.Exception(
                 () => generator.NextLessThanOrEqualTo(date)
             );
+
+            // Assert
+
+            Assert.NotEqual(date.Kind, generator.Kind);
+            Assert.IsType<ArgumentException>(exception);
+        }
+
+        [Theory]
+        [MemberData(nameof(UnitsMemberData))]
+        public void NextLessThanOrEqualTo_AlwaysReturnsValuesOnGranularityUnitsInterval(
+            DateTimeUnit granularity) {
+
+            // Arrange
+
+            var generator = new DateTimeGenerator(granularity);
+
+            // Act
+
+            var generated = generator.NextLessThanOrEqualTo(DateTime.UtcNow);
+
+            // Assert
+
+            AssertOnIntervalForGranularity(generated, granularity);
         }
 
         [Fact]
         public void NextGreaterThan_MismatchedKind() {
-            var date = DateTime.SpecifyKind(DateTime.Now, DateTimeKind.Local);
-            var generator = new DateTimeGenerator();
 
-            Assert.NotEqual(date.Kind, generator.Kind);
-            Assert.Throws<ArgumentException>(
+            // Arrange
+
+            var generator = new DateTimeGenerator();
+            var date = DateTime.SpecifyKind(DateTime.Now, DateTimeKind.Local);
+
+            // Act
+
+            var exception = Record.Exception(
                 () => generator.NextGreaterThan(date)
             );
+
+            // Assert
+
+            Assert.NotEqual(date.Kind, generator.Kind);
+            Assert.IsType<ArgumentException>(exception);
+        }
+
+        [Theory]
+        [MemberData(nameof(UnitsMemberData))]
+        public void NextGreaterThan_AlwaysReturnsValuesOnGranularityUnitsInterval(
+            DateTimeUnit granularity) {
+
+            // Arrange
+
+            var generator = new DateTimeGenerator(granularity);
+
+            // Act
+
+            var generated = generator.NextGreaterThan(DateTime.UtcNow);
+
+            // Assert
+
+            AssertOnIntervalForGranularity(generated, granularity);
         }
 
         [Fact]
         public void NextGreaterThanOrEqualTo_MismatchedKind() {
+
+            // Arrange
+
             var date = DateTime.SpecifyKind(DateTime.Now, DateTimeKind.Local);
             var generator = new DateTimeGenerator();
 
-            Assert.NotEqual(date.Kind, generator.Kind);
-            Assert.Throws<ArgumentException>(
+            // Act
+
+            var exception = Record.Exception(
                 () => generator.NextGreaterThanOrEqualTo(date)
             );
+
+            // Assert
+
+            Assert.IsType<ArgumentException>(exception);
+            Assert.NotEqual(date.Kind, generator.Kind);
+        }
+
+        [Theory]
+        [MemberData(nameof(UnitsMemberData))]
+        public void NextGreaterThanOrEqualTo_AlwaysReturnsValuesOnGranularityUnitsInterval(
+            DateTimeUnit granularity) {
+
+            // Arrange
+
+            var generator = new DateTimeGenerator(granularity);
+
+            // Act
+
+            var generated = generator.NextGreaterThanOrEqualTo(DateTime.UtcNow);
+
+            // Assert
+
+            AssertOnIntervalForGranularity(generated, granularity);
         }
 
         [Fact]
         public void EqualityComparer_MismatchedKind() {
+
+            // Arrange
+
             var now = DateTime.Now;
             var generator = new DateTimeGenerator();
             var comparer = generator.EqualityComparer;
 
-            Assert.False(
+            // Act
+
+            var isEqual =
                 comparer.Equals(
                     DateTime.SpecifyKind(now, DateTimeKind.Local),
                     DateTime.SpecifyKind(now, DateTimeKind.Utc)
-                )
-            );
+                );
+
+            // Assert
+
+            Assert.False(isEqual);
+        }
+
+        [Theory]
+        [InlineData(DateTimeKind.Utc)]
+        public void EqualityComparer_RespectsGranularity(DateTimeKind kind) {
+
+            // Arrange
+
+            var value = new DateTime(2006, 07, 22, 05, 15, 45, kind);
+            var generator = new DateTimeGenerator(DateTimeUnit.Hour);
+            var comparer = generator.EqualityComparer;
+
+            // Act
+
+            var isEqual = comparer.Equals(value, new DateTime(2006, 07, 22, 05, 45, 05, kind));
+
+            // Assert
+
+            Assert.True(isEqual);
         }
 
         [Fact]
         public void Comparer_MismatchedKind() {
+
+            // Arrange
+
             var now = DateTime.Now;
             var generator = new DateTimeGenerator();
             var comparer = generator.Comparer;
 
-            Assert.Throws<ArgumentException>(
+            // Act
+
+            var exception = Record.Exception(
                 () => comparer.Compare(
                     DateTime.SpecifyKind(now, DateTimeKind.Local),
                     DateTime.SpecifyKind(now, DateTimeKind.Utc)
                 )
+            );
+
+            // Assert
+
+            Assert.IsType<ArgumentException>(exception);
+        }
+
+        [Theory]
+        [InlineData(DateTimeKind.Utc)]
+        public void Comparer_RespectsGranulatiry(DateTimeKind kind) {
+
+            // Arrange
+
+            var value = new DateTime(2006, 07, 22, 05, 15, 45, kind);
+            var generator = new DateTimeGenerator(DateTimeUnit.Minute);
+            var comparer = generator.Comparer;
+
+            // Act
+
+            var comparison = comparer.Compare(
+                value,
+                new DateTime(2006, 07, 22, 05, 15, 15, kind)
+            );
+
+            // Assert
+
+            Assert.Equal(0, comparison);
+        }
+
+        private static void AssertOnIntervalForGranularity(
+            DateTime generated,
+            DateTimeUnit granularity) {
+
+            var isHoursZeroed = false;
+            var isMinutesZeroed = false;
+            var isSecondsZeroed = false;
+            var isMillisecondsZeroed = false;
+
+            switch (granularity) {
+                case DateTimeUnit.Day:
+                    isHoursZeroed = true;
+                    goto case DateTimeUnit.Hour;
+                case DateTimeUnit.Hour:
+                    isMinutesZeroed = true;
+                    goto case DateTimeUnit.Minute;
+                case DateTimeUnit.Minute:
+                    isSecondsZeroed = true;
+                    goto case DateTimeUnit.Second;
+                case DateTimeUnit.Second:
+                    isMillisecondsZeroed = true;
+                    goto case DateTimeUnit.Millisecond;
+                case DateTimeUnit.Millisecond:
+                    break;
+                case DateTimeUnit.Tick:
+                    return;
+                default:
+                    throw new NotSupportedException(
+                        $"The {nameof(DateTimeUnit)} '{granularity}' is not supported."
+                    );
+            }
+
+            Assert.Equal(
+                new DateTime(
+                    generated.Year,
+                    generated.Month,
+                    generated.Day,
+                    isHoursZeroed ? 0 : generated.Hour,
+                    isMinutesZeroed ? 0 : generated.Minute,
+                    isSecondsZeroed ? 0 : generated.Second,
+                    isMillisecondsZeroed ? 0 : generated.Millisecond,
+                    generated.Kind
+                ),
+                generated
             );
         }
 

--- a/test/Peddler.Tests/KindSensitiveDateTimeComparerTests.cs
+++ b/test/Peddler.Tests/KindSensitiveDateTimeComparerTests.cs
@@ -1,34 +1,39 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
+using Invio.Xunit;
 using Xunit;
 
 namespace Peddler {
 
-    public class KindSensitiveDateTimeComparerTests {
+    [UnitTest]
+    public sealed class KindSensitiveDateTimeComparerTests {
 
+        private static IList<DateTimeUnit> units { get; }
         private static IList<DateTimeKind> kinds { get; }
         private static IGenerator<Int64> tickGenerator { get; }
 
         static KindSensitiveDateTimeComparerTests() {
-            kinds = new DateTimeKind[] {
+            units = ImmutableList.Create<DateTimeUnit>(
+                DateTimeUnit.Tick,
+                DateTimeUnit.Millisecond,
+                DateTimeUnit.Second,
+                DateTimeUnit.Minute,
+                DateTimeUnit.Hour,
+                DateTimeUnit.Day
+            );
+
+            kinds = ImmutableList.Create<DateTimeKind>(
                 DateTimeKind.Unspecified,
                 DateTimeKind.Local,
                 DateTimeKind.Utc
-            };
+            );
 
             tickGenerator = new Int64Generator(DateTime.MinValue.Ticks, DateTime.MaxValue.Ticks);
         }
 
-        public static IEnumerable<object[]> Kinds {
-            get {
-                foreach (var kind in kinds) {
-                    yield return new object[] { kind };
-                }
-            }
-        }
-
-        public static IEnumerable<object[]> MismatchedKinds {
+        public static IEnumerable<object[]> Compare_MismatchedKinds_MemberData {
             get {
                 foreach (var leftKind in kinds) {
                     foreach (var rightKind in kinds) {
@@ -43,15 +48,24 @@ namespace Peddler {
         }
 
         [Theory]
-        [MemberData(nameof(MismatchedKinds))]
+        [MemberData(nameof(Compare_MismatchedKinds_MemberData))]
         public void Compare_KindMismatch(DateTimeKind leftKind, DateTimeKind rightKind) {
+
+            // Arrange
+
             var comparer = new KindSensitiveDateTimeComparer();
             var left = new DateTime(tickGenerator.Next(), leftKind);
             var right = new DateTime(tickGenerator.Next(), rightKind);
 
-            var exception = Assert.Throws<ArgumentException>(
+            // Act
+
+            var exception = Record.Exception(
                 () => comparer.Compare(left, right)
             );
+
+            // Assert
+
+            Assert.IsType<ArgumentException>(exception);
 
             Assert.Equal(
                 $"The DateTimeKind of 'left' ({left.Kind:G}) " +
@@ -61,20 +75,115 @@ namespace Peddler {
             );
         }
 
+        public static IEnumerable<object[]> Compare_MatchingKinds_MemberData {
+            get {
+                foreach (var kind in kinds) {
+                    foreach (var unit in units) {
+                        yield return new object[] { kind, unit };
+                    }
+                }
+            }
+        }
+
         [Theory]
-        [MemberData(nameof(Kinds))]
-        public void Compare_MatchingKinds(DateTimeKind kind) {
-            var comparer = new KindSensitiveDateTimeComparer();
-            var original = new DateTime(DateTime.MinValue.Ticks + 100, kind);
+        [MemberData(nameof(Compare_MatchingKinds_MemberData))]
+        public void Compare_MatchingKinds(
+            DateTimeKind kind,
+            DateTimeUnit granularity) {
+
+            // Arrange
+
+            var comparer = new KindSensitiveDateTimeComparer(granularity);
+            var original = new DateTime(DateTime.UtcNow.Ticks - 100, kind);
+            var ticksPerUnit = DateTimeUtilities.GetTicksPerUnit(granularity);
+
+            // Act
 
             var same = new DateTime(original.Ticks, kind);
+            var later = new DateTime(original.Ticks + ticksPerUnit, kind);
+            var earlier = new DateTime(original.Ticks - ticksPerUnit, kind);
+
+            // Assert
+
             Assert.Equal(0, comparer.Compare(original, same));
-
-            var later = new DateTime(original.Ticks + 1, kind);
             Assert.Equal(-1, comparer.Compare(original, later));
-
-            var earlier = new DateTime(original.Ticks - 1, kind);
             Assert.Equal(1, comparer.Compare(original, earlier));
+        }
+
+        public static IEnumerable<object[]> Compare_UnitsCauseValuesToBeFlooredToPreviousInterval_MemberData {
+            get {
+                foreach (var kind in kinds) {
+                    yield return new object[] {
+                        new DateTime(2016, 10, 11, 01, 23, 56, 111, kind),
+                        new DateTime(2016, 10, 11, 01, 23, 56, 111, kind).AddTicks(111),
+                        new DateTime(2016, 10, 11, 01, 23, 56, 111, kind).AddTicks(999),
+                        DateTimeUnit.Millisecond
+                    };
+
+                    yield return new object[] {
+                        new DateTime(2016, 10, 11, 01, 23, 56, 000, kind),
+                        new DateTime(2016, 10, 11, 01, 23, 56, 111, kind),
+                        new DateTime(2016, 10, 11, 01, 23, 56, 999, kind),
+                        DateTimeUnit.Second
+                    };
+
+                    yield return new object[] {
+                        new DateTime(2016, 10, 11, 01, 23, 00, kind),
+                        new DateTime(2016, 10, 11, 01, 23, 59, kind),
+                        new DateTime(2016, 10, 11, 01, 23, 01, kind),
+                        DateTimeUnit.Minute
+                    };
+
+                    yield return new object[] {
+                        new DateTime(2016, 10, 11, 01, 00, 00, kind),
+                        new DateTime(2016, 10, 11, 01, 11, 11, kind),
+                        new DateTime(2016, 10, 11, 01, 59, 59, kind),
+                        DateTimeUnit.Hour
+                    };
+
+                    yield return new object[] {
+                        new DateTime(2016, 10, 11, 00, 00, 00, kind),
+                        new DateTime(2016, 10, 11, 01, 23, 45, kind),
+                        new DateTime(2016, 10, 11, 23, 59, 59, kind),
+                        DateTimeUnit.Day
+                    };
+                }
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(Compare_UnitsCauseValuesToBeFlooredToPreviousInterval_MemberData))]
+        public void Compare_UnitsCauseValuesToBeFlooredToPreviousInterval(
+            DateTime onInterval,
+            DateTime highInInterval,
+            DateTime lowInInterval,
+            DateTimeUnit granularity) {
+
+            // Arrange
+
+            var comparer = new KindSensitiveDateTimeComparer(granularity);
+            var ticksPerUnit = DateTimeUtilities.GetTicksPerUnit(granularity);
+
+            var nextInternal = onInterval.AddTicks(ticksPerUnit);
+            var previousIntervalMaximum = onInterval.AddTicks(-1L);
+
+            // Act
+
+            var highToLow = comparer.Compare(highInInterval, lowInInterval);
+            var highToInterval = comparer.Compare(highInInterval, onInterval);
+            var intervalToLow = comparer.Compare(onInterval, lowInInterval);
+
+            var currentIntervalToNextInterval = comparer.Compare(onInterval, nextInternal);
+            var currentToPreviousInterval = comparer.Compare(onInterval, previousIntervalMaximum);
+
+            // Assert
+
+            Assert.Equal(0, highToLow);
+            Assert.Equal(0, highToInterval);
+            Assert.Equal(0, intervalToLow);
+
+            Assert.Equal(-1, currentIntervalToNextInterval);
+            Assert.Equal(1, currentToPreviousInterval);
         }
 
     }

--- a/test/Peddler.Tests/KindSensitiveDateTimeEqualityComparerTests.cs
+++ b/test/Peddler.Tests/KindSensitiveDateTimeEqualityComparerTests.cs
@@ -1,34 +1,40 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
+using Invio.Xunit;
 using Xunit;
 
 namespace Peddler {
 
-    public class KindSensitiveDateTimeEqualityComparerTests {
+    [UnitTest]
+    public sealed class KindSensitiveDateTimeEqualityComparerTests {
 
+        private static IList<DateTimeUnit> units { get; }
         private static IList<DateTimeKind> kinds { get; }
         private static IGenerator<Int64> tickGenerator { get; }
 
         static KindSensitiveDateTimeEqualityComparerTests() {
-            kinds = new DateTimeKind[] {
+            units = ImmutableList.Create<DateTimeUnit>(
+                DateTimeUnit.Tick,
+                DateTimeUnit.Millisecond,
+                DateTimeUnit.Second,
+                DateTimeUnit.Minute,
+                DateTimeUnit.Hour,
+                DateTimeUnit.Day
+            );
+
+            kinds = ImmutableList.Create<DateTimeKind>(
                 DateTimeKind.Unspecified,
                 DateTimeKind.Local,
                 DateTimeKind.Utc
-            };
+            );
 
-            tickGenerator = new Int64Generator(DateTime.MinValue.Ticks, DateTime.MaxValue.Ticks);
+            tickGenerator =
+                new Int64Generator(DateTime.MinValue.Ticks, DateTime.MaxValue.Ticks);
         }
 
-        public static IEnumerable<object[]> Kinds {
-            get {
-                foreach (var kind in kinds) {
-                    yield return new object[] { kind };
-                }
-            }
-        }
-
-        public static IEnumerable<object[]> MismatchedKinds {
+        public static IEnumerable<object[]> MismatchedKinds_MemberData {
             get {
                 foreach (var leftKind in kinds) {
                     foreach (var rightKind in kinds) {
@@ -43,7 +49,7 @@ namespace Peddler {
         }
 
         [Theory]
-        [MemberData(nameof(MismatchedKinds))]
+        [MemberData(nameof(MismatchedKinds_MemberData))]
         public void Equals_KindMismatch(DateTimeKind leftKind, DateTimeKind rightKind) {
             var ticks = tickGenerator.Next();
             var comparer = new KindSensitiveDateTimeEqualityComparer();
@@ -54,29 +60,158 @@ namespace Peddler {
             Assert.False(comparer.Equals(left, right));
         }
 
+        public static IEnumerable<object[]> MatchingKinds_MemberData {
+            get {
+                foreach (var unit in units) {
+                    foreach (var kind in kinds) {
+                        yield return new object[] { kind, unit };
+                    }
+                }
+            }
+        }
+
         [Theory]
-        [MemberData(nameof(Kinds))]
-        public void Equals_MatchingKinds(DateTimeKind kind) {
-            var comparer = new KindSensitiveDateTimeEqualityComparer();
-            var original = new DateTime(DateTime.MinValue.Ticks, kind);
+        [MemberData(nameof(MatchingKinds_MemberData))]
+        public void Equals_MatchingKinds(DateTimeKind kind, DateTimeUnit granularity) {
 
-            var same = new DateTime(DateTime.MinValue.Ticks, kind);
+            // Arrange
+
+            var comparer = new KindSensitiveDateTimeEqualityComparer(granularity);
+            var original = new DateTime(DateTime.Now.Ticks, kind);
+            var ticksPerUnit = DateTimeUtilities.GetTicksPerUnit(granularity);
+
+            // Act
+
+            var same = new DateTime(original.Ticks, kind);
+            var different = new DateTime(original.Ticks + ticksPerUnit, kind);
+
+            // Assert
+
             Assert.True(comparer.Equals(original, same));
-
-            var different = new DateTime(DateTime.MinValue.Ticks + 1, kind);
             Assert.False(comparer.Equals(original, different));
         }
 
         [Theory]
-        [MemberData(nameof(Kinds))]
-        public void GetHashCode_MatchingKinds(DateTimeKind kind) {
+        [MemberData(nameof(MatchingKinds_MemberData))]
+        public void GetHashCode_MatchingKinds(DateTimeKind kind, DateTimeUnit granularity) {
+
+            // Arrange
+
             var ticks = tickGenerator.Next();
-            var comparer = new KindSensitiveDateTimeEqualityComparer();
+            var comparer = new KindSensitiveDateTimeEqualityComparer(granularity);
 
-            var left = new DateTime(ticks, kind);
-            var right = new DateTime(ticks, kind);
+            // Act
 
-            Assert.Equal(comparer.GetHashCode(left), comparer.GetHashCode(right));
+            var left = comparer.GetHashCode(new DateTime(ticks, kind));
+            var right = comparer.GetHashCode(new DateTime(ticks, kind));
+
+            // Assert
+
+            Assert.Equal(left, right);
+        }
+
+        public static IEnumerable<object[]> UnitsCauseValuesToBeFlooredToPreviousInterval_MemberData {
+            get {
+                foreach (var kind in kinds) {
+                    yield return new object[] {
+                        new DateTime(2016, 10, 11, 01, 23, 56, 111, kind),
+                        new DateTime(2016, 10, 11, 01, 23, 56, 111, kind).AddTicks(111),
+                        new DateTime(2016, 10, 11, 01, 23, 56, 111, kind).AddTicks(999),
+                        DateTimeUnit.Millisecond
+                    };
+
+                    yield return new object[] {
+                        new DateTime(2016, 10, 11, 01, 23, 56, 000, kind),
+                        new DateTime(2016, 10, 11, 01, 23, 56, 111, kind),
+                        new DateTime(2016, 10, 11, 01, 23, 56, 999, kind),
+                        DateTimeUnit.Second
+                    };
+
+                    yield return new object[] {
+                        new DateTime(2016, 10, 11, 01, 23, 00, kind),
+                        new DateTime(2016, 10, 11, 01, 23, 59, kind),
+                        new DateTime(2016, 10, 11, 01, 23, 01, kind),
+                        DateTimeUnit.Minute
+                    };
+
+                    yield return new object[] {
+                        new DateTime(2016, 10, 11, 01, 00, 00, kind),
+                        new DateTime(2016, 10, 11, 01, 11, 11, kind),
+                        new DateTime(2016, 10, 11, 01, 59, 59, kind),
+                        DateTimeUnit.Hour
+                    };
+
+                    yield return new object[] {
+                        new DateTime(2016, 10, 11, 00, 00, 00, kind),
+                        new DateTime(2016, 10, 11, 01, 23, 45, kind),
+                        new DateTime(2016, 10, 11, 23, 59, 59, kind),
+                        DateTimeUnit.Day
+                    };
+                }
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(UnitsCauseValuesToBeFlooredToPreviousInterval_MemberData))]
+        public void Equals_UnitsCauseValuesToBeFlooredToPreviousInterval(
+            DateTime onInterval,
+            DateTime highInInterval,
+            DateTime lowInInterval,
+            DateTimeUnit granularity) {
+
+            // Arrange
+
+            var comparer = new KindSensitiveDateTimeEqualityComparer(granularity);
+            var ticksPerUnit = DateTimeUtilities.GetTicksPerUnit(granularity);
+
+            var nextInternal = onInterval.AddTicks(ticksPerUnit);
+            var previousIntervalMaximum = onInterval.AddTicks(-1L);
+
+            // Act
+
+            var highToLow = comparer.Equals(highInInterval, lowInInterval);
+            var highToInterval = comparer.Equals(highInInterval, onInterval);
+            var intervalToLow = comparer.Equals(onInterval, lowInInterval);
+
+            var currentIntervalToNextInterval = comparer.Equals(onInterval, nextInternal);
+            var currentToPreviousInterval = comparer.Equals(onInterval, previousIntervalMaximum);
+
+            // Assert
+
+            Assert.True(highToLow);
+            Assert.True(highToInterval);
+            Assert.True(intervalToLow);
+
+            Assert.False(currentIntervalToNextInterval);
+            Assert.False(currentToPreviousInterval);
+        }
+
+        [Theory]
+        [MemberData(nameof(UnitsCauseValuesToBeFlooredToPreviousInterval_MemberData))]
+        public void GetHashCode_UnitsCauseValuesToBeFlooredToPreviousInterval(
+            DateTime onInterval,
+            DateTime highInInterval,
+            DateTime lowInInterval,
+            DateTimeUnit granularity) {
+
+            // Arrange
+
+            var comparer = new KindSensitiveDateTimeEqualityComparer(granularity);
+            var ticksPerUnit = DateTimeUtilities.GetTicksPerUnit(granularity);
+
+            var nextInternal = onInterval.AddTicks(ticksPerUnit);
+            var previousIntervalMaximum = onInterval.AddTicks(-1L);
+
+            // Act
+
+            var onIntervalHashCode = comparer.GetHashCode(lowInInterval);
+            var highInIntervalHashCode = comparer.GetHashCode(highInInterval);
+            var lowInIntervalHashCode = comparer.GetHashCode(lowInInterval);
+
+            // Assert
+
+            Assert.Equal(onIntervalHashCode, highInIntervalHashCode);
+            Assert.Equal(onIntervalHashCode, lowInIntervalHashCode);
         }
 
     }


### PR DESCRIPTION
Resolves #58. 

This is needed for us to have a way to generate "date only" `DateTime` values. This also allows us to generate `DateTime` values that lack sub-microsecond levels of specificity for persistence into MySQL.